### PR TITLE
Add support for defining SpectralDimension for NamedMethod.

### DIFF
--- a/docs/api_py/methods/BlochDecayCTSpectrum.rst
+++ b/docs/api_py/methods/BlochDecayCTSpectrum.rst
@@ -14,13 +14,14 @@ Bloch Decay Central Transition Spectrum method
 .. doctest::
 
     >>> from mrsimulator.methods import BlochDecayCTSpectrum
+    >>> from mrsimulator.method import SpectralDimension
     >>> Bloch_CT_method = BlochDecayCTSpectrum(
     ...     channels=["1H"],
     ...     rotor_frequency=5000,  # in Hz
     ...     rotor_angle=54.735 * 3.14159 / 180,  # in rad
     ...     magnetic_flux_density=9.4,  # in T
     ...     spectral_dimensions=[
-    ...         dict(count=1024, spectral_width=50000, reference_offset=-8000)
+    ...         SpectralDimension(count=1024, spectral_width=50000, reference_offset=-8000)
     ...     ],
     ... )
 

--- a/docs/api_py/methods/BlochDecaySpectrum.rst
+++ b/docs/api_py/methods/BlochDecaySpectrum.rst
@@ -14,13 +14,14 @@ Bloch Decay Spectrum method
 .. doctest::
 
     >>> from mrsimulator.methods import BlochDecaySpectrum
+    >>> from mrsimulator.method import SpectralDimension
     >>> Bloch_method = BlochDecaySpectrum(
     ...     channels=["1H"],
     ...     rotor_frequency=5000,  # in Hz
     ...     rotor_angle=54.735 * 3.14159 / 180,  # in rad
     ...     magnetic_flux_density=9.4,  # in T
     ...     spectral_dimensions=[
-    ...         dict(count=1024, spectral_width=50000, reference_offset=-8000)
+    ...         SpectralDimension(count=1024, spectral_width=50000, reference_offset=-8000)
     ...     ],
     ... )
 

--- a/docs/introduction/ethanol_example.rst
+++ b/docs/introduction/ethanol_example.rst
@@ -19,6 +19,7 @@ Here we import everything we will use in this example
 
     from mrsimulator import Simulator, Site, SpinSystem, Coupling
     from mrsimulator.methods import BlochDecaySpectrum
+    from mrsimulator.method import SpectralDimension
     from mrsimulator import signal_processing as sp
 
 Spin Systems
@@ -158,7 +159,7 @@ These methods emulate simple 1-pulse acquire experiments.
         channels=["1H"],
         magnetic_flux_density=9.4,  # in T
         spectral_dimensions=[
-            dict(
+            SpectralDimension(
                 count=16000,
                 spectral_width=1.5e3,  # in Hz
                 reference_offset=950,  # in Hz
@@ -171,7 +172,7 @@ These methods emulate simple 1-pulse acquire experiments.
         channels=["13C"],
         magnetic_flux_density=9.4,  # in T
         spectral_dimensions=[
-            dict(
+            SpectralDimension(
                 count=32000,
                 spectral_width=8e3,  # in Hz
                 reference_offset=4e3,  # in Hz

--- a/docs/introduction/getting_started.rst
+++ b/docs/introduction/getting_started.rst
@@ -85,6 +85,7 @@ Some attributes of the method still need to be provided as seen below.
 
     # Import the BlochDecaySpectrum class
     from mrsimulator.methods import BlochDecaySpectrum
+    from mrsimulator.method import SpectralDimension
 
     # Create a BlochDecaySpectrum object
     method = BlochDecaySpectrum(
@@ -93,7 +94,7 @@ Some attributes of the method still need to be provided as seen below.
         rotor_angle=54.735 * 3.14159 / 180,  # in rad (magic angle)
         rotor_frequency=3000,  # in Hz
         spectral_dimensions=[
-            dict(
+            SpectralDimension(
                 count=2048,
                 spectral_width=80e3,  # in Hz
                 reference_offset=6e3,  # in Hz

--- a/docs/user_guide/methods_library/bloch_decay.rst
+++ b/docs/user_guide/methods_library/bloch_decay.rst
@@ -7,6 +7,7 @@ Bloch decay spectrum.
 .. code-block:: python
 
     from mrsimulator.methods import BlochDecaySpectrum
+    from mrsimulator.method import SpectralDimension
 
     method = BlochDecaySpectrum(
         channels=["1H"],
@@ -14,7 +15,7 @@ Bloch decay spectrum.
         rotor_angle=54.735 * 3.14159 / 180,  # in rad
         magnetic_flux_density=9.4,  # in tesla
         spectral_dimensions=[
-            dict(
+            SpectralDimension(
                 count=1024,
                 spectral_width=25e3,  # in Hz
                 reference_offset=-4e3,  # in Hz

--- a/docs/user_guide/methods_library/bloch_decay_CT.rst
+++ b/docs/user_guide/methods_library/bloch_decay_CT.rst
@@ -7,6 +7,7 @@ Bloch decay central transition selective spectrum.
 .. code-block:: python
 
     from mrsimulator.methods import BlochDecayCTSpectrum
+    from mrsimulator.method import SpectralDimension
 
     method = BlochDecayCTSpectrum(
         channels=["1H"],
@@ -14,7 +15,7 @@ Bloch decay central transition selective spectrum.
         rotor_angle=54.735 * 3.14159 / 180,  # in rad
         magnetic_flux_density=9.4,  # in tesla
         spectral_dimensions=[
-            dict(
+            SpectralDimension(
                 count=1024,
                 spectral_width=25e3,  # in Hz
                 reference_offset=-4e3,  # in Hz

--- a/docs/user_guide/methods_library/mq_vas.rst
+++ b/docs/user_guide/methods_library/mq_vas.rst
@@ -9,18 +9,19 @@ is also sheared such that the correlating dimensions are the isotropic dimension
 .. code-block:: python
 
     from mrsimulator.methods import ThreeQ_VAS
+    from mrsimulator.method import SpectralDimension
 
     method = ThreeQ_VAS(
         channels=["87Rb"],
         magnetic_flux_density=7,  # in T
         spectral_dimensions=[
-            dict(
+            SpectralDimension(
                 count=128,
                 spectral_width=3e3,  # in Hz
                 reference_offset=-2e3,  # in Hz
                 label="Isotropic dimension",
             ),
-            dict(
+            SpectralDimension(
                 count=512,
                 spectral_width=1e4,  # in Hz
                 reference_offset=-5e3,  # in Hz

--- a/docs/user_guide/methods_library/ssb2d.rst
+++ b/docs/user_guide/methods_library/ssb2d.rst
@@ -8,19 +8,20 @@ dimension is fixed at infinite spinning speed
 .. code-block:: python
 
     from mrsimulator.methods import SSB2D
+    from mrsimulator.method import SpectralDimension
 
     method = SSB2D(
         channels=["13C"],
         magnetic_flux_density=7,  # in T
         rotor_frequency=1500,  # in Hz
         spectral_dimensions=[
-            dict(
+            SpectralDimension(
                 count=16,
                 spectral_width=16 * 1500,  # in Hz (= count * rotor_frequency)
                 reference_offset=-5e3,  # in Hz
                 label="Sideband dimension",
             ),
-            dict(
+            SpectralDimension(
                 count=512,
                 spectral_width=1e4,  # in Hz
                 reference_offset=-4e3,  # in Hz

--- a/docs/user_guide/methods_library/st_vas.rst
+++ b/docs/user_guide/methods_library/st_vas.rst
@@ -8,18 +8,19 @@ speed for these methods is fixed at infinite speed.
 .. code-block:: python
 
     from mrsimulator.methods import ST1_VAS
+    from mrsimulator.method import SpectralDimension
 
     method = ST1_VAS(
         channels=["87Rb"],
         magnetic_flux_density=9.4,  # in T
         spectral_dimensions=[
-            dict(
+            SpectralDimension(
                 count=128,
                 spectral_width=1e3,  # in Hz
                 reference_offset=-5e3,  # in Hz
                 label="Isotropic dimension",
             ),
-            dict(
+            SpectralDimension(
                 count=256,
                 spectral_width=1e4,  # in Hz
                 reference_offset=-3e3,  # in Hz

--- a/docs/user_guide/simulator/simulator.rst
+++ b/docs/user_guide/simulator/simulator.rst
@@ -20,6 +20,7 @@ spin systems and methods to a simulator object.
 
     from mrsimulator import Site, Simulator, SpinSystem
     from mrsimulator.methods import BlochDecaySpectrum
+    from mrsimulator.method import SpectralDimension
 
     # Setup the spin system and method objects
     system1 = SpinSystem(sites=[Site(isotope="1H")])  # Proton spin system
@@ -111,6 +112,7 @@ not be sufficient.
 
     from mrsimulator import Simulator, SpinSystem, Site
     from mrsimulator.methods import BlochDecaySpectrum
+    from mrsimulator.method import SpectralDimension
     from mrsimulator.spin_system.tensors import SymmetricTensor
 
     # create a site with a large anisotropy of 100 ppm
@@ -121,7 +123,7 @@ not be sufficient.
     method = BlochDecaySpectrum(
         channels=["29Si"],
         rotor_frequency=200,
-        spectral_dimensions=[dict(count=1024, spectral_width=25000)],
+        spectral_dimensions=[SpectralDimension(count=1024, spectral_width=25000)],
     )
 
     sim = Simulator(spin_systems=[Si29_sys], methods=[method])
@@ -189,7 +191,7 @@ Consider the following examples.
     sim.methods[0] = BlochDecaySpectrum(
         channels=["29Si"],
         rotor_frequency=0,  # in Hz
-        spectral_dimensions=[dict(count=1024, spectral_width=25000)],
+        spectral_dimensions=[SpectralDimension(count=1024, spectral_width=25000)],
     )
 
     # simulate and plot
@@ -285,7 +287,7 @@ following example.
 
     # Create a method representing a simple 1-pulse acquire experiment
     method = BlochDecaySpectrum(
-        channels=["1H"], spectral_dimensions=[dict(count=1024, spectral_width=10000)]
+        channels=["1H"], spectral_dimensions=[SpectralDimension(count=1024, spectral_width=10000)]
     )
 
     # Create simulator object, simulate, and plot

--- a/examples_source/1D_simulation(crystalline)/plot_0_Wollastonite.py
+++ b/examples_source/1D_simulation(crystalline)/plot_0_Wollastonite.py
@@ -17,6 +17,7 @@ from mrsimulator import Simulator, SpinSystem, Site
 from mrsimulator import signal_processing as sp
 from mrsimulator.methods import BlochDecaySpectrum
 from mrsimulator.spin_system.tensors import SymmetricTensor
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 3
 
@@ -54,7 +55,7 @@ method = BlochDecaySpectrum(
     magnetic_flux_density=14.1,  # in T
     rotor_frequency=1500,  # in Hz
     spectral_dimensions=[
-        dict(
+        SpectralDimension(
             count=2048,
             spectral_width=25000,  # in Hz
             reference_offset=-10000,  # in Hz

--- a/examples_source/1D_simulation(crystalline)/plot_1_PotassiumSulfate.py
+++ b/examples_source/1D_simulation(crystalline)/plot_1_PotassiumSulfate.py
@@ -16,6 +16,7 @@ from mrsimulator import Simulator, SpinSystem, Site
 from mrsimulator import signal_processing as sp
 from mrsimulator.methods import BlochDecayCTSpectrum
 from mrsimulator.spin_system.tensors import SymmetricTensor
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 3
 
@@ -36,7 +37,7 @@ method = BlochDecayCTSpectrum(
     magnetic_flux_density=21.14,  # in T
     rotor_frequency=14000,  # in Hz
     spectral_dimensions=[
-        dict(
+        SpectralDimension(
             count=2048,
             spectral_width=5000,  # in Hz
             reference_offset=22500,  # in Hz

--- a/examples_source/1D_simulation(crystalline)/plot_2_Coesite.py
+++ b/examples_source/1D_simulation(crystalline)/plot_2_Coesite.py
@@ -17,6 +17,7 @@ from mrsimulator import Simulator, SpinSystem, Site
 from mrsimulator import signal_processing as sp
 from mrsimulator.methods import BlochDecayCTSpectrum
 from mrsimulator.spin_system.tensors import SymmetricTensor
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 2
 
@@ -68,7 +69,7 @@ method = BlochDecayCTSpectrum(
     channels=["17O"],
     rotor_frequency=14000,  # in Hz
     spectral_dimensions=[
-        dict(
+        SpectralDimension(
             count=2048,
             spectral_width=50000,  # in Hz
             label=r"$^{17}$O resonances",

--- a/examples_source/1D_simulation(crystalline)/plot_3_quad_csa.py
+++ b/examples_source/1D_simulation(crystalline)/plot_3_quad_csa.py
@@ -22,6 +22,7 @@ import matplotlib.pyplot as plt
 from mrsimulator import Simulator, SpinSystem, Site
 from mrsimulator.methods import BlochDecayCTSpectrum
 from mrsimulator.spin_system.tensors import SymmetricTensor
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 1
 
@@ -48,7 +49,7 @@ method = BlochDecayCTSpectrum(
     magnetic_flux_density=11.74,  # in T
     rotor_frequency=0,  # in Hz
     spectral_dimensions=[
-        dict(
+        SpectralDimension(
             count=1024,
             spectral_width=1e5,  # in Hz
             reference_offset=22500,  # in Hz

--- a/examples_source/1D_simulation(crystalline)/plot_6_dipolar_coupled.py
+++ b/examples_source/1D_simulation(crystalline)/plot_6_dipolar_coupled.py
@@ -13,6 +13,7 @@ from mrsimulator import Simulator, SpinSystem, Site, Coupling
 from mrsimulator.methods import BlochDecaySpectrum
 from mrsimulator import signal_processing as sp
 from mrsimulator.spin_system.tensors import SymmetricTensor
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 1
 
@@ -34,7 +35,7 @@ spin_system = SpinSystem(
 method = BlochDecaySpectrum(
     channels=["13C"],
     magnetic_flux_density=9.4,  # in T
-    spectral_dimensions=[dict(count=2048, spectral_width=8.0e4)],
+    spectral_dimensions=[SpectralDimension(count=2048, spectral_width=8.0e4)],
 )
 
 # %%

--- a/examples_source/1D_simulation(crystalline)/plot_7_CAS_dipolar_J.py
+++ b/examples_source/1D_simulation(crystalline)/plot_7_CAS_dipolar_J.py
@@ -19,6 +19,7 @@ from mrsimulator import Simulator, SpinSystem, Site, Coupling
 from mrsimulator.methods import BlochDecaySpectrum
 from mrsimulator import signal_processing as sp
 from mrsimulator.spin_system.tensors import SymmetricTensor
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 1
 
@@ -71,7 +72,7 @@ methods = [
         channels=["13C"],
         magnetic_flux_density=9.4,  # in T
         rotor_frequency=vr,  # in Hz
-        spectral_dimensions=[dict(count=2048, spectral_width=8.0e4)],
+        spectral_dimensions=[SpectralDimension(count=2048, spectral_width=8.0e4)],
     )
     for vr in spin_rates
 ]

--- a/examples_source/1D_simulation(macro_amorphous)/plot_3_amorphous_like.py
+++ b/examples_source/1D_simulation(macro_amorphous)/plot_3_amorphous_like.py
@@ -19,6 +19,7 @@ from scipy.stats import multivariate_normal
 from mrsimulator import Simulator
 from mrsimulator.methods import BlochDecaySpectrum
 from mrsimulator.utils.collection import single_site_system_generator
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 2
 
@@ -102,7 +103,7 @@ spin_systems = single_site_system_generator(
 method = BlochDecaySpectrum(
     channels=["29Si"],
     spectral_dimensions=[
-        dict(spectral_width=25000, reference_offset=-7000)  # values in Hz
+        SpectralDimension(spectral_width=25000, reference_offset=-7000)  # values in Hz
     ],
 )
 
@@ -148,7 +149,7 @@ sim.methods[0] = BlochDecaySpectrum(
     rotor_frequency=5000,  # in Hz
     rotor_angle=1.57079,  # in rads, equivalent to 90 deg.
     spectral_dimensions=[
-        dict(spectral_width=25000, reference_offset=-7000)  # values in Hz
+        SpectralDimension(spectral_width=25000, reference_offset=-7000)  # values in Hz
     ],
 )
 sim.config.number_of_sidebands = 8  # eight sidebands are sufficient for this example
@@ -172,7 +173,7 @@ sim.methods[0] = BlochDecaySpectrum(
     rotor_frequency=1000,  # in Hz
     rotor_angle=54.735 * np.pi / 180.0,  # in rads
     spectral_dimensions=[
-        dict(spectral_width=25000, reference_offset=-7000)  # values in Hz
+        SpectralDimension(spectral_width=25000, reference_offset=-7000)  # values in Hz
     ],
 )
 sim.config.number_of_sidebands = 16  # sixteen sidebands are sufficient for this example

--- a/examples_source/1D_simulation(macro_amorphous)/plot_4_amorphous_like_quad.py
+++ b/examples_source/1D_simulation(macro_amorphous)/plot_4_amorphous_like_quad.py
@@ -14,6 +14,7 @@ from scipy.stats import multivariate_normal
 from mrsimulator import Simulator
 from mrsimulator.methods import BlochDecayCTSpectrum
 from mrsimulator.utils.collection import single_site_system_generator
+from mrsimulator.method import SpectralDimension
 
 # %%
 # In this section, we illustrate the simulation of a quadrupolar spectrum arising from
@@ -83,7 +84,7 @@ spin_systems = single_site_system_generator(
 # Observe the static :math:`^{27}\text{Al}` NMR spectrum simulation. First,
 # create a central transition selective Bloch decay spectrum method.
 static_method = BlochDecayCTSpectrum(
-    channels=["27Al"], spectral_dimensions=[dict(spectral_width=80000)]
+    channels=["27Al"], spectral_dimensions=[SpectralDimension(spectral_width=80000)]
 )
 
 # %%
@@ -111,7 +112,7 @@ MAS_method = BlochDecayCTSpectrum(
     rotor_frequency=25000,  # in Hz
     rotor_angle=54.735 * np.pi / 180.0,  # in rads
     spectral_dimensions=[
-        dict(spectral_width=30000, reference_offset=-4000)  # values in Hz
+        SpectralDimension(spectral_width=30000, reference_offset=-4000)  # values in Hz
     ],
 )
 sim.methods[0] = MAS_method

--- a/examples_source/1D_simulation(macro_amorphous)/plot_5_czjzek_distribution.py
+++ b/examples_source/1D_simulation(macro_amorphous)/plot_5_czjzek_distribution.py
@@ -17,6 +17,7 @@ from mrsimulator import Simulator
 from mrsimulator.methods import BlochDecaySpectrum, BlochDecayCTSpectrum
 from mrsimulator.models import CzjzekDistribution
 from mrsimulator.utils.collection import single_site_system_generator
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 4
 
@@ -118,7 +119,7 @@ sim.methods = [
     BlochDecayCTSpectrum(
         channels=["71Ga"],
         magnetic_flux_density=4.8,  # in T
-        spectral_dimensions=[dict(count=2048, spectral_width=1.2e6)],
+        spectral_dimensions=[SpectralDimension(count=2048, spectral_width=1.2e6)],
     )
 ]  # add the method
 sim.run()

--- a/examples_source/1D_simulation(macro_amorphous)/plot_6_extended_czjzek.py
+++ b/examples_source/1D_simulation(macro_amorphous)/plot_6_extended_czjzek.py
@@ -18,6 +18,7 @@ from mrsimulator import Simulator
 from mrsimulator.methods import BlochDecaySpectrum, BlochDecayCTSpectrum
 from mrsimulator.models import ExtCzjzekDistribution
 from mrsimulator.utils.collection import single_site_system_generator
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 5
 
@@ -118,7 +119,7 @@ sim.methods = [
     BlochDecayCTSpectrum(
         channels=["71Ga"],
         magnetic_flux_density=9.4,  # in T
-        spectral_dimensions=[dict(count=2048, spectral_width=2e5)],
+        spectral_dimensions=[SpectralDimension(count=2048, spectral_width=2e5)],
     )
 ]  # add the method
 sim.run()
@@ -141,7 +142,7 @@ sim.methods = [
         magnetic_flux_density=9.4,  # in T
         rotor_frequency=25000,  # in Hz
         spectral_dimensions=[
-            dict(count=2048, spectral_width=2e5, reference_offset=-1e4)
+            SpectralDimension(count=2048, spectral_width=2e5, reference_offset=-1e4)
         ],
     )
 ]  # add the method

--- a/examples_source/2D_simulation(crystalline)/plot_0_MQMAS_RbNO3.py
+++ b/examples_source/2D_simulation(crystalline)/plot_0_MQMAS_RbNO3.py
@@ -17,6 +17,7 @@ from mrsimulator import Simulator, SpinSystem, Site
 from mrsimulator.methods import ThreeQ_VAS
 from mrsimulator import signal_processing as sp
 from mrsimulator.spin_system.tensors import SymmetricTensor
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 3
 
@@ -48,13 +49,13 @@ method = ThreeQ_VAS(
     channels=["87Rb"],
     magnetic_flux_density=9.4,  # in T
     spectral_dimensions=[
-        dict(
+        SpectralDimension(
             count=128,
             spectral_width=7e3,  # in Hz
             reference_offset=-7e3,  # in Hz
             label="Isotropic dimension",
         ),
-        dict(
+        SpectralDimension(
             count=256,
             spectral_width=1e4,  # in Hz
             reference_offset=-4e3,  # in Hz

--- a/examples_source/2D_simulation(crystalline)/plot_1_MQMAS_albite.py
+++ b/examples_source/2D_simulation(crystalline)/plot_1_MQMAS_albite.py
@@ -16,6 +16,7 @@ from mrsimulator import Simulator, SpinSystem, Site
 from mrsimulator.methods import ThreeQ_VAS
 from mrsimulator import signal_processing as sp
 from mrsimulator.spin_system.tensors import SymmetricTensor
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 2
 
@@ -36,13 +37,13 @@ method = ThreeQ_VAS(
     channels=["27Al"],
     magnetic_flux_density=7,  # in T
     spectral_dimensions=[
-        dict(
+        SpectralDimension(
             count=256,
             spectral_width=1e4,  # in Hz
             reference_offset=-3e3,  # in Hz
             label="Isotropic dimension",
         ),
-        dict(
+        SpectralDimension(
             count=512,
             spectral_width=1e4,  # in Hz
             reference_offset=4e3,  # in Hz

--- a/examples_source/2D_simulation(crystalline)/plot_1_STMAS_RbNO3.py
+++ b/examples_source/2D_simulation(crystalline)/plot_1_STMAS_RbNO3.py
@@ -15,6 +15,7 @@ from mrsimulator import Simulator, SpinSystem, Site
 from mrsimulator.methods import ST1_VAS
 from mrsimulator import signal_processing as sp
 from mrsimulator.spin_system.tensors import SymmetricTensor
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 3
 
@@ -55,13 +56,13 @@ for angle in angles:
             magnetic_flux_density=7,  # in T
             rotor_angle=angle * 3.14159 / 180,  # in rad (magic angle)
             spectral_dimensions=[
-                dict(
+                SpectralDimension(
                     count=256,
                     spectral_width=3e3,  # in Hz
                     reference_offset=-2.4e3,  # in Hz
                     label="Isotropic dimension",
                 ),
-                dict(
+                SpectralDimension(
                     count=512,
                     spectral_width=5e3,  # in Hz
                     reference_offset=-4e3,  # in Hz

--- a/examples_source/2D_simulation(crystalline)/plot_4_3QMAS_Coesite.py
+++ b/examples_source/2D_simulation(crystalline)/plot_4_3QMAS_Coesite.py
@@ -15,6 +15,7 @@ import matplotlib.pyplot as plt
 from mrsimulator import Simulator
 from mrsimulator.methods import ThreeQ_VAS
 from mrsimulator import signal_processing as sp
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 2
 
@@ -30,14 +31,14 @@ method = ThreeQ_VAS(
     channels=["17O"],
     magnetic_flux_density=11.74,  # in T
     spectral_dimensions=[
-        dict(
+        SpectralDimension(
             count=256,
             spectral_width=5e3,  # in Hz
             reference_offset=-2.5e3,  # in Hz
             label="Isotropic dimension",
         ),
         # The last spectral dimension block is the direct-dimension
-        dict(
+        SpectralDimension(
             count=256,
             spectral_width=2e4,  # in Hz
             reference_offset=0,  # in Hz

--- a/examples_source/2D_simulation(crystalline)/plot_6_PASS_itraconazole_drug.py
+++ b/examples_source/2D_simulation(crystalline)/plot_6_PASS_itraconazole_drug.py
@@ -16,6 +16,7 @@ import matplotlib.pyplot as plt
 from mrsimulator import Simulator
 from mrsimulator.methods import SSB2D
 from mrsimulator import signal_processing as sp
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 2
 
@@ -38,12 +39,12 @@ PASS = SSB2D(
     magnetic_flux_density=11.74,
     rotor_frequency=2000,
     spectral_dimensions=[
-        dict(
+        SpectralDimension(
             count=20 * 4,
             spectral_width=2000 * 20,  # value in Hz
             label="Anisotropic dimension",
         ),
-        dict(
+        SpectralDimension(
             count=1024,
             spectral_width=3e4,  # value in Hz
             reference_offset=1.1e4,  # value in Hz

--- a/examples_source/2D_simulation(crystalline)/plot_7_QSSB_Rb2SO4.py
+++ b/examples_source/2D_simulation(crystalline)/plot_7_QSSB_Rb2SO4.py
@@ -16,6 +16,7 @@ import matplotlib.pyplot as plt
 from mrsimulator import Simulator, SpinSystem, Site
 from mrsimulator.methods import SSB2D
 from mrsimulator.spin_system.tensors import SymmetricTensor
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 2
 
@@ -46,12 +47,12 @@ qmat = SSB2D(
     magnetic_flux_density=9.4,
     rotor_frequency=2604,
     spectral_dimensions=[
-        dict(
+        SpectralDimension(
             count=32 * 4,
             spectral_width=2604 * 32,  # in Hz
             label="Anisotropic dimension",
         ),
-        dict(
+        SpectralDimension(
             count=512,
             spectral_width=50000,  # in Hz
             label="Fast MAS dimension",

--- a/examples_source/2D_simulation(macro_amorphous)/plot_0_crystalline_disorder.py
+++ b/examples_source/2D_simulation(macro_amorphous)/plot_0_crystalline_disorder.py
@@ -18,6 +18,7 @@ from mrsimulator import Simulator
 from mrsimulator.methods import ThreeQ_VAS
 from mrsimulator.models import ExtCzjzekDistribution
 from mrsimulator.utils.collection import single_site_system_generator
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 2
 
@@ -104,13 +105,13 @@ method = ThreeQ_VAS(
     magnetic_flux_density=9.4,  # in T
     rotor_angle=54.735 * np.pi / 180,
     spectral_dimensions=[
-        dict(
+        SpectralDimension(
             count=96,
             spectral_width=7e3,  # in Hz
             reference_offset=-7e3,  # in Hz
             label="Isotropic dimension",
         ),
-        dict(
+        SpectralDimension(
             count=256,
             spectral_width=1e4,  # in Hz
             reference_offset=-4e3,  # in Hz

--- a/examples_source/2D_simulation(macro_amorphous)/plot_1_I=2.5.py
+++ b/examples_source/2D_simulation(macro_amorphous)/plot_1_I=2.5.py
@@ -20,6 +20,7 @@ from mrsimulator import Simulator
 from mrsimulator.methods import ThreeQ_VAS
 from mrsimulator.models import CzjzekDistribution
 from mrsimulator.utils.collection import single_site_system_generator
+from mrsimulator.method import SpectralDimension
 
 
 # %%
@@ -89,13 +90,13 @@ len(spin_systems)
 mqvas = ThreeQ_VAS(
     channels=["27Al"],
     spectral_dimensions=[
-        dict(
+        SpectralDimension(
             count=512,
             spectral_width=26718.475776,  # in Hz
             reference_offset=-4174.76184,  # in Hz
             label="Isotropic dimension",
         ),
-        dict(
+        SpectralDimension(
             count=512,
             spectral_width=2e4,  # in Hz
             reference_offset=2e3,  # in Hz

--- a/fitting_source/1D_fitting/plot_1_29Si_cuspidine.py
+++ b/fitting_source/1D_fitting/plot_1_29Si_cuspidine.py
@@ -29,6 +29,7 @@ from mrsimulator.methods import BlochDecaySpectrum
 from mrsimulator import signal_processing as sp
 from mrsimulator.utils import spectral_fitting as sf
 from mrsimulator.spin_system.tensors import SymmetricTensor
+from mrsimulator.method import SpectralDimension
 
 # sphinx_gallery_thumbnail_number = 3
 
@@ -98,7 +99,7 @@ MAS = BlochDecaySpectrum(
     magnetic_flux_density=7.1,  # in T
     rotor_frequency=780,  # in Hz
     spectral_dimensions=[
-        dict(
+        SpectralDimension(
             count=2048,
             spectral_width=25000,  # in Hz
             reference_offset=-5000,  # in Hz

--- a/src/mrsimulator/methods/base.py
+++ b/src/mrsimulator/methods/base.py
@@ -213,23 +213,22 @@ class BaseNamedMethod(BaseMethod):
             obj_keys = ev_obj.dict(exclude={"property_units"}).keys()
             check_keys = default_dim["events"][i].keys()
             for k in obj_keys:  # iterate over event attributes
-                a = False
+                fail = False
                 if k in check_keys:
                     obj_attr, default_attr, check_attr = [
                         getattr(_, k) for _ in [ev_obj, default_obj, ev_check]
                     ]
-                    a = (
-                        obj_attr != default_attr and  # not default (user passed value)
-                        obj_attr != check_attr and  # passed attr does not match base
-                        default_attr is not None
-                    )
+                    fail_1 = obj_attr != default_attr  # not default (user passed value)
+                    fail_2 = obj_attr != check_attr  # passed attr does not match base
+                    fail_3 = default_attr is not None
+                    fail = fail_1 and fail_2 and fail_3
                     setattr(ev_obj, k, check_attr)
                 elif k in required and k in method_dict:
                     # True if passed attr does not match global attr defined by method
-                    a = getattr(ev_obj, k) != method_dict[k]
+                    fail = getattr(ev_obj, k) != method_dict[k]
                     # Set event attr to global method attr
                     setattr(ev_obj, k, method_dict[k])
-                if a:
+                if fail:
                     raise ImmutableEventError(cls.__name__)
 
 

--- a/src/mrsimulator/methods/tests/test_MQVAS.py
+++ b/src/mrsimulator/methods/tests/test_MQVAS.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 import pytest
+from mrsimulator.method import SpectralDimension
 from mrsimulator.method.query import TransitionQuery
 from mrsimulator.methods import FiveQ_VAS
 from mrsimulator.methods import SevenQ_VAS
@@ -86,7 +87,9 @@ def test_3Q_VAS_general():
 
 def test_5Q_VAS_general():
     """5Q-VAS method test"""
-    mth = FiveQ_VAS(channels=["17O"], spectral_dimensions=[{}, {}])
+    mth = FiveQ_VAS(
+        channels=["17O"], spectral_dimensions=[SpectralDimension(), SpectralDimension()]
+    )
 
     assert mth.name == "FiveQ_VAS"
     assert mth.description == "Simulate a 5Q variable-angle spinning spectrum."
@@ -138,3 +141,8 @@ def test_7Q_VAS_general():
         "name": "SevenQ_VAS",
         **sample_test_output(-7),
     }
+
+
+def test_mix_SpectralDimension_and_dict():
+    with pytest.raises(Exception, match="Use either SpectralDimension or dict objects"):
+        _ = SevenQ_VAS(channels=["51V"], spectral_dimensions=[{}, SpectralDimension()])

--- a/src/mrsimulator/methods/tests/test_base.py
+++ b/src/mrsimulator/methods/tests/test_base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+from mrsimulator.method import SpectralDimension
 from mrsimulator.methods.base import BaseNamedMethod1D
 from mrsimulator.methods.base import BaseNamedMethod2D
 from mrsimulator.utils.error import ImmutableEventError
@@ -8,8 +9,17 @@ from mrsimulator.utils.error import NamedMethodError
 
 def test_BaseNamedMethod1D_spectral_dimension_count():
     e = "Method requires exactly 1 spectral dimensions, given 2."
+    # test for SpectralDimension passed as dictionary
     with pytest.raises(ValueError, match=f".*{e}.*"):
         BaseNamedMethod1D(spectral_dimensions=[{}, {}])
+    # test for SpectralDimension passed as object
+    with pytest.raises(ValueError, match=f".*{e}.*"):
+        BaseNamedMethod1D(
+            spectral_dimensions=[
+                SpectralDimension(),
+                SpectralDimension(),
+            ]
+        )
 
 
 def test_BaseNamedMethod1D_setting_events():
@@ -26,8 +36,12 @@ def test_BaseNamedMethod1D_setting_name():
 
 def test_BaseNamedMethod2D_spectral_dimension_count():
     e = "Method requires exactly 2 spectral dimensions, given 1."
+    # test for SpectralDimension passed as dictionary
     with pytest.raises(ValueError, match=f".*{e}.*"):
         BaseNamedMethod2D(channels=["1H"], spectral_dimensions=[{}])
+    # test for SpectralDimension passed as object
+    with pytest.raises(ValueError, match=f".*{e}.*"):
+        BaseNamedMethod2D(channels=["1H"], spectral_dimensions=[SpectralDimension()])
 
 
 def test_BaseNamedMethod2D_setting_events():

--- a/src/mrsimulator/methods/utils.py
+++ b/src/mrsimulator/methods/utils.py
@@ -112,6 +112,10 @@ def parse_spectral_dimensions(py_dict):
 
 def check_for_at_least_one_events(py_dict):
     """Update events to [{}] if not present."""
+    check_dict = [isinstance(sp, dict) for sp in py_dict["spectral_dimensions"]]
+    if not all(check_dict):
+        raise Exception("Use either SpectralDimension or dict objects.")
+
     _ = [
         item.update({"events": [{}]})
         for item in py_dict["spectral_dimensions"]

--- a/tests/test_orientations_and_triangle_interpolation.py
+++ b/tests/test_orientations_and_triangle_interpolation.py
@@ -148,18 +148,7 @@ def test_triangle_rasterization1():
     ]
     for scl in SCALE:
         for i, list_ in enumerate(f_list):
-            lst1, lst2 = np.asarray(list_) * scl
-            amp1 = np.zeros((20 * scl, 2 * 20 * scl), dtype=np.float64)
-            amp2 = np.zeros(2 * 20 * scl, dtype=np.float64)
-            amp3 = np.zeros(2 * 20 * scl, dtype=np.float64)
-
-            clib.triangle_interpolation2D(lst1, lst2, amp1)
-            clib.triangle_interpolation1D(lst1, amp2)
-            clib.triangle_interpolation1D(lst2, amp3)
-
-            amp1 = amp1[:, ::2]  # + 1j * amp1[:, 1::2]
-            amp2 = amp2[::2]  # + 1j * amp2[1::2]
-            amp3 = amp3[::2]  # + 1j * amp3[1::2]
+            amp1, amp2, amp3, lst1, lst2 = get_amps_from_interpolation(list_, scl)
 
             # plot_2d_raster(amp1, lst1, lst2, amp3, amp2, save=f"ras1_{i}", scale=scl)
             assert np.allclose(amp2, amp1.sum(axis=1), atol=1e-15)


### PR DESCRIPTION
Add support of the use of SpectralDimension objects for library methods. For example,

```py
mqvas = ThreeQ_VAS(
    channels=['27Al'],
    rotor_angle=54.735*3.14159/180,
    spectral_dimensions=[
        SpectralDimension(count=512, spectral_width=50e3),
        SpectralDimension(count=128, spectral_width=20e3),
    ]
)
```