### PR TITLE
Migrate datasets to snnmr.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,4 +122,4 @@ If you use mrsimulator in your publication, please consider citing the following
 
 - Srivastava DJ, Vosegaard T, Massiot D, Grandinetti PJ (2020) Core Scientific Dataset Model: A lightweight and portable model and file format for multi-dimensional scientific data. PLOS ONE 15(1): e0225953. https://doi.org/10.1371/journal.pone.0225953
 
-_Additionally, if you use lmfit for least-squares fitting, consider citing the lmfit package._ Zenodo. http://doi.org/10.5281/zenodo.4516651
+_Additionally, if you use lmfit for least-squares fitting, consider citing the lmfit package._ Zenodo. https://doi.org/10.5281/zenodo.4516651

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -41,7 +41,7 @@
 
     {%- if show_sphinx %}
     {% trans sphinx_version=sphinx_version|e %}
-    Created using <a href="http://www.sphinx-doc.org/en/stable/">Sphinx</a> {{ sphinx_version }}.
+    Created using <a href="https://www.sphinx-doc.org/en/stable/">Sphinx</a> {{ sphinx_version }}.
     {% endtrans %} &nbsp;
     {%- endif %}
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 #
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
-# http://www.sphinx-doc.org/en/master/config
+# https://www.sphinx-doc.org/en/master/config
 # -- Path setup --------------------------------------------------------------
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -335,9 +335,9 @@ html_theme_options = {
     # Enable Google Web Font. Defaults to false
     # "googlewebfont": True,
     # Set the URL of Google Web Font's CSS.
-    # Defaults to 'http://fonts.googleapis.com/css?family=Text+Me+One'
-    # "googlewebfont_url": "http://fonts.googleapis.com/css?family=Roboto+Script+One",  # NOQA
-    # "googlewebfont_url": "http://fonts.googleapis.com/css2?family=Inter",
+    # Defaults to 'https://fonts.googleapis.com/css?family=Text+Me+One'
+    # "googlewebfont_url": "https://fonts.googleapis.com/css?family=Roboto+Script+One",  # NOQA
+    # "googlewebfont_url": "https://fonts.googleapis.com/css2?family=Inter",
     # Set the Style of Google Web Font's CSS.
     # Defaults to "font-family: 'Text Me One', sans-serif;"
     # "googlewebfont_style": "font-family: Helvetica",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -319,7 +319,7 @@ If you use mrsimulator in your publication, please consider citing the following
 
 *Additionally, if you use lmfit for least-squares fitting, consider citing the lmfit package.*
 
-- Matt Newville; Renee Otten; Andrew Nelson; Antonino Ingargiola; Till Stensitzki; Dan Allan; Austin Fox; Faustin Carter; Michał; Dima Pustakhod; lneuhaus; Sebastian Weigand; Ray Osborn; Glenn; Christoph Deil; Mark; Allan L. R. Hansen; Gustavo Pasquevich; Leon Foks; Nicholas Zobrist; Oliver Frost; Alexandre Beelen; Stuermer; kwertyops; Anthony Polloreno; Shane Caldwell; Anthony Almarza; Arun Persaud; Ben Gamari; Benjamin F. Maier. (2021, February 7). lmfit/lmfit-py 1.0.2 (Version 1.0.2). Zenodo. http://doi.org/10.5281/zenodo.4516651
+- Matt Newville; Renee Otten; Andrew Nelson; Antonino Ingargiola; Till Stensitzki; Dan Allan; Austin Fox; Faustin Carter; Michał; Dima Pustakhod; lneuhaus; Sebastian Weigand; Ray Osborn; Glenn; Christoph Deil; Mark; Allan L. R. Hansen; Gustavo Pasquevich; Leon Foks; Nicholas Zobrist; Oliver Frost; Alexandre Beelen; Stuermer; kwertyops; Anthony Polloreno; Shane Caldwell; Anthony Almarza; Arun Persaud; Ben Gamari; Benjamin F. Maier. (2021, February 7). lmfit/lmfit-py 1.0.2 (Version 1.0.2). Zenodo. https://doi.org/10.5281/zenodo.4516651
 
 .. only:: html
 

--- a/docs/installation/colab.rst
+++ b/docs/installation/colab.rst
@@ -1,7 +1,7 @@
 
 Colaboratory is a Google research project. It is a Jupyter notebook environment that
 runs entirely in the cloud. Launch a new notebook on
-`Colab <http://colab.research.google.com>`_. We recommend going through the *Welcome to Colab!*
+`Colab <https://colab.research.google.com>`_. We recommend going through the *Welcome to Colab!*
 tutorial if you are new to Notebooks.
 
 By default, Colaboratory has an older version of ``numpy`` installed which first needs to be

--- a/docs/installation/requirements.rst
+++ b/docs/installation/requirements.rst
@@ -13,7 +13,7 @@ Package dependencies
 
 **Required packages**
 
-- `NumPy>=1.17 <http://www.numpy.org>`_
+- `NumPy>=1.17 <https://www.numpy.org>`_
 - openblas
 - cython>=0.29.14
 - typing-extensions>=3.7

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -30,7 +30,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://sphinx-doc.org/
 	exit /b 1
 )
 

--- a/fitting_source/1D_fitting/plot_1_29Si_cuspidine.py
+++ b/fitting_source/1D_fitting/plot_1_29Si_cuspidine.py
@@ -38,8 +38,9 @@ from mrsimulator.method import SpectralDimension
 # ------------------
 # Use the `csdmpy <https://csdmpy.readthedocs.io/en/stable/index.html>`_
 # module to load the synthetic dataset as a CSDM object.
-file_ = "https://sandbox.zenodo.org/record/835664/files/synthetic_cuspidine_test.csdf?"
-synthetic_experiment = cp.load(file_).real
+host = "https://ssnmr.org/sites/default/files/mrsimulator/"
+filename = "synthetic_cuspidine_test.csdf"
+synthetic_experiment = cp.load(host + filename).real
 
 # standard deviation of noise from the dataset
 sigma = 0.03383338

--- a/fitting_source/1D_fitting/plot_2_PASS_cross_sections.py
+++ b/fitting_source/1D_fitting/plot_2_PASS_cross_sections.py
@@ -24,7 +24,7 @@ from mrsimulator.spin_system.tensors import SymmetricTensor
 # %%
 # Import the dataset
 # ------------------
-name = "https://sandbox.zenodo.org/record/835664/files/LHistidine_cross_section.csdf"
+name = "https://ssnmr.org/sites/default/files/mrsimulator/LHistidine_cross_section.csdf"
 pass_cross_section = cp.load(name)
 
 # standard deviation of noise from the dataset

--- a/fitting_source/1D_fitting/plot_3_Na2SiO3.py
+++ b/fitting_source/1D_fitting/plot_3_Na2SiO3.py
@@ -36,7 +36,7 @@ from mrsimulator.spin_system.tensors import SymmetricTensor
 # Import the experimental data. We use dataset file serialized with the CSDM
 # file-format, using the
 # `csdmpy <https://csdmpy.readthedocs.io/en/stable/index.html>`_ module.
-filename = "https://sandbox.zenodo.org/record/835664/files/Na2SiO3_O17.csdf"
+filename = "https://ssnmr.org/sites/default/files/mrsimulator/Na2SiO3_O17.csdf"
 experiment = cp.load(filename)
 
 # standard deviation of noise from the dataset

--- a/fitting_source/1D_fitting/plot_4_11B_Quad_NMR.py
+++ b/fitting_source/1D_fitting/plot_4_11B_Quad_NMR.py
@@ -23,8 +23,9 @@ from mrsimulator.spin_system.tensors import SymmetricTensor
 # %%
 # Import the dataset
 # ------------------
-filename = "https://sandbox.zenodo.org/record/835664/files/11B_lithum_orthoborate.csdf"
-experiment = cp.load(filename)
+host = "https://ssnmr.org/sites/default/files/mrsimulator/"
+filename = "11B_lithum_orthoborate.csdf"
+experiment = cp.load(host + filename)
 
 # standard deviation of noise from the dataset
 sigma = 0.08078374

--- a/fitting_source/2D_fitting/plot_1_Rb2SO4_QMAT.py
+++ b/fitting_source/2D_fitting/plot_1_Rb2SO4_QMAT.py
@@ -25,7 +25,7 @@ from mrsimulator.spin_system.tensors import SymmetricTensor
 # %%
 # Import the dataset
 # ------------------
-filename = "https://sandbox.zenodo.org/record/835664/files/Rb2SO4_QMAT.csdf"
+filename = "https://ssnmr.org/sites/default/files/mrsimulator/Rb2SO4_QMAT.csdf"
 qmat_data = cp.load(filename)
 
 # standard deviation of noise from the dataset

--- a/fitting_source/2D_fitting/plot_4_NiCl2.2D2O_shifting-d.py
+++ b/fitting_source/2D_fitting/plot_4_NiCl2.2D2O_shifting-d.py
@@ -27,7 +27,7 @@ from mrsimulator.method import Method, SpectralDimension, SpectralEvent
 # %%
 # Import the dataset
 # ------------------
-filename = "https://sandbox.zenodo.org/record/835664/files/NiCl2.2D2O.csdf"
+filename = "https://ssnmr.org/sites/default/files/mrsimulator/NiCl2.2D2O.csdf"
 experiment = cp.load(filename)
 
 # standard deviation of noise from the dataset

--- a/src/mrsimulator/tests/test_root_level_funcs.py
+++ b/src/mrsimulator/tests/test_root_level_funcs.py
@@ -82,7 +82,7 @@ def test_load():
     assert application_r == application
 
     # Load from external URL. May break in the future
-    load("http://ssnmr.org/sites/default/files/mrsimulator/test.mrsim")
+    load("https://ssnmr.org/sites/default/files/mrsimulator/test.mrsim")
 
     os.remove("test.mrsim")
 

--- a/src/mrsimulator/utils/error.py
+++ b/src/mrsimulator/utils/error.py
@@ -89,6 +89,6 @@ class FileConversionError(Exception):
         message = message or (
             "Unable to convert the requested mrsim file/dict to a compatible "
             "structure. See the documentation at "
-            "http://mrsimulator.readthedocs.io/en/stable/ to find out more."
+            "https://mrsimulator.readthedocs.io/en/stable/ to find out more."
         )
         super().__init__(message)

--- a/src/mrsimulator/utils/utils.py
+++ b/src/mrsimulator/utils/utils.py
@@ -5,7 +5,7 @@ __email__ = ["srivastava.89@osu.edu", "giammar.7@osu.edu"]
 
 # VO7_QUERY_WARNING = (
 #     "Definition of the transition query object has changed since v0.7. Follow the "
-#     "documentation at http://mrsimulator.readthedocs.io/en/stable/ to find more."
+#     "documentation at https://mrsimulator.readthedocs.io/en/stable/ to find more."
 # )
 MRSIMULATOR_KEYS = {"simulator", "signal_processors", "version", "application"}
 SIM_KEYWORDS = {

--- a/tests/2D_spectrum_tests/test_das.py
+++ b/tests/2D_spectrum_tests/test_das.py
@@ -52,6 +52,7 @@ def test_DAS():
                 "count": 912,
                 "spectral_width": 5e3,  # in Hz
                 "reference_offset": 0,  # in Hz
+                "origin_offset": O17_1.isotope.gyromagnetic_ratio * B0 * 1e6,  # in Hz
                 "label": "DAS isotropic dimension",
                 "events": [
                     {
@@ -71,6 +72,7 @@ def test_DAS():
                 "count": 2048,
                 "spectral_width": 2e4,  # in Hz
                 "reference_offset": 0,  # in Hz
+                "origin_offset": O17_1.isotope.gyromagnetic_ratio * B0 * 1e6,  # in Hz
                 "label": "MAS dimension",
                 "events": [
                     {


### PR DESCRIPTION
Should resolve readthedocs failing to build when zenoodo is down.

Also added `origin_offset` to `test_das.py` which should allow the CI tests to pass on GitHub. Still don't know why `origin_offset` is not added to the spectral dimensions in GitHub Actions but is correctly added when running pytest locally...