### PR TITLE
Fix bug for coupled quad symmetry query.

### DIFF
--- a/src/mrsimulator/method/query.py
+++ b/src/mrsimulator/method/query.py
@@ -55,7 +55,7 @@ class SymmetryQuery(Parseable):
     """
 
     P: List[int] = Field(
-        default=[-1],
+        default=[0],
         description=(
             "A list of p symmetry functions per site. Here p = Δm = (m_f-m_i) is the "
             "difference between spin quantum numbers of the final and initial states."
@@ -159,7 +159,7 @@ class TransitionQuery(Parseable):
     @staticmethod
     def cartesian_product_indexing(permutation):
         """Return Cartesian product of indexes"""
-        permutation_length = [np.arange(len(p)) for p in permutation if len(p) != 0]
+        permutation_length = [np.arange(len(p)) for p in permutation]
         if permutation_length == []:
             return np.asarray([])
 

--- a/src/mrsimulator/method/tests/lib_tests/test_methods.py
+++ b/src/mrsimulator/method/tests/lib_tests/test_methods.py
@@ -35,11 +35,12 @@ sample_method_dict = dict(
     ],
 )
 
+sq_tq = {"transition_query": [{"ch1": {"P": [-1]}}]}
 sample_test_output = {
     "count": 1024,
     "events": [
-        {"fraction": 27 / 17, "freq_contrib": ["Quad2_0"]},
-        {"fraction": 1, "freq_contrib": ["Quad2_4"]},
+        {"fraction": 27 / 17, "freq_contrib": ["Quad2_0"], **sq_tq},
+        {"fraction": 1, "freq_contrib": ["Quad2_4"], **sq_tq},
     ],
 }
 
@@ -58,8 +59,8 @@ def test_03():
         magnetic_flux_density=9.4,  # in T
         rotor_frequency=1000000000000.0,
         spectral_dimensions=[
-            {"count": 1024, "spectral_width": 5e4, "events": [{}]},
-            {"count": 1024, "spectral_width": 5e4, "events": [{}]},
+            {"count": 1024, "spectral_width": 5e4, "events": [sq_tq]},
+            {"count": 1024, "spectral_width": 5e4, "events": [sq_tq]},
         ],
     )
 

--- a/src/mrsimulator/method/tests/test_event.py
+++ b/src/mrsimulator/method/tests/test_event.py
@@ -91,7 +91,7 @@ def basic_spectral_and_constant_time_event_tests(the_event, type_="spectral"):
         magnetic_flux_density="11.7 T",
         rotor_frequency="25000.0 Hz",
         rotor_angle=f"{angle} rad",
-        transition_query=[{"ch1": {"P": [-1]}}],
+        transition_query=[{"ch1": {"P": [0]}}],
     )
     should_be = {
         "magnetic_flux_density": 11.7,
@@ -105,7 +105,7 @@ def basic_spectral_and_constant_time_event_tests(the_event, type_="spectral"):
         assert the_event.json(units=False) == {
             "fraction": 1.2,
             **should_be,
-            "transition_query": [{"ch1": {"P": [-1]}}],
+            "transition_query": [{"ch1": {"P": [0]}}],
         }
 
     if type_ == "constant_duration":
@@ -114,7 +114,7 @@ def basic_spectral_and_constant_time_event_tests(the_event, type_="spectral"):
         assert the_event.json(units=False) == {
             "duration": 1.2,
             **should_be,
-            "transition_query": [{"ch1": {"P": [-1.0]}}],
+            "transition_query": [{"ch1": {"P": [0]}}],
         }
 
 

--- a/src/mrsimulator/method/tests/test_method.py
+++ b/src/mrsimulator/method/tests/test_method.py
@@ -58,7 +58,7 @@ def basic_method_tests(the_method):
 
     # json()
 
-    evt = [{"fraction": 0.5, "transition_query": [{"ch1": {"P": [-1]}}]}] * 2
+    evt = [{"fraction": 0.5, "transition_query": [{"ch1": {"P": [0]}}]}] * 2
     serialize = {
         "name": "test worked",
         "description": "test worked again",
@@ -151,7 +151,7 @@ def test_method():
     assert the_method.simulation == csdm_dataset
 
     # json()
-    event_dictionary_ = {"fraction": 0.5, "transition_query": [{"ch1": {"P": [-1]}}]}
+    event_dictionary_ = {"fraction": 0.5, "transition_query": [{"ch1": {"P": [0]}}]}
     dimension_dictionary_ = {
         "count": 1024,
         "spectral_width": "100.0 Hz",
@@ -173,7 +173,7 @@ def test_method():
     assert serialize == method_dictionary_
 
     # json(units=False)
-    event_dictionary_ = {"fraction": 0.5, "transition_query": [{"ch1": {"P": [-1]}}]}
+    event_dictionary_ = {"fraction": 0.5, "transition_query": [{"ch1": {"P": [0]}}]}
     dimension_dictionary_ = {
         "count": 1024,
         "spectral_width": 100.0,

--- a/src/mrsimulator/method/tests/test_query.py
+++ b/src/mrsimulator/method/tests/test_query.py
@@ -36,7 +36,7 @@ def test_TransitionQuery():
     assert obj2.name is None
     assert obj2.description is None
     assert obj2.label is None
-    assert obj2.ch1 == SymmetryQuery(P=[-1]), "TransitionQuery ch1 not equal."
+    assert obj2.ch1 == SymmetryQuery(P=[0]), "TransitionQuery ch1 not equal."
     assert obj2.ch2 == SymmetryQuery(P=[-2], D=[2]), "TransitionQuery ch2 not equal."
     assert obj2.ch3 is None, "TransitionQuery ch3 not equal."
 

--- a/src/mrsimulator/method/tests/test_spectral_dimension.py
+++ b/src/mrsimulator/method/tests/test_spectral_dimension.py
@@ -90,7 +90,7 @@ def basic_spectral_dimension_tests(the_dimension):
                 "magnetic_flux_density": "9.6 T",
                 "rotor_angle": "0.9553059660790962 rad",
                 "rotor_frequency": "1000.0 Hz",
-                "transition_query": [{"ch1": {"P": [-1]}}],
+                "transition_query": [{"ch1": {"P": [0]}}],
             }
         ],
     )
@@ -108,7 +108,7 @@ def basic_spectral_dimension_tests(the_dimension):
                 "magnetic_flux_density": 9.6,
                 "rotor_angle": 0.9553059660790962,
                 "rotor_frequency": 1000.0,
-                "transition_query": [{"ch1": {"P": [-1]}}],
+                "transition_query": [{"ch1": {"P": [0]}}],
             }
         ],
     )
@@ -178,14 +178,14 @@ def test_spectral_dimension():
                 "magnetic_flux_density": "9.6 T",
                 "rotor_angle": "0.9553059660790962 rad",
                 "rotor_frequency": "1000.0 Hz",
-                "transition_query": [{"ch1": {"P": [-1]}}],
+                "transition_query": [{"ch1": {"P": [0]}}],
             },
             {
                 "fraction": 0.5,
                 "magnetic_flux_density": "9.6 T",
                 "rotor_angle": "0.9553059660790962 rad",
                 "rotor_frequency": "1000.0 Hz",
-                "transition_query": [{"ch1": {"P": [-1]}}],
+                "transition_query": [{"ch1": {"P": [0]}}],
             },
         ],
     )
@@ -203,7 +203,7 @@ def test_spectral_dimension():
                 "magnetic_flux_density": 9.6,
                 "rotor_angle": 0.9553059660790962,
                 "rotor_frequency": 1000.0,
-                "transition_query": [{"ch1": {"P": [-1]}}],
+                "transition_query": [{"ch1": {"P": [0]}}],
             },
             {
                 "fraction": 0.5,
@@ -211,7 +211,7 @@ def test_spectral_dimension():
                 "magnetic_flux_density": 9.6,
                 "rotor_angle": 0.9553059660790962,
                 "rotor_frequency": 1000.0,
-                "transition_query": [{"ch1": {"P": [-1]}}],
+                "transition_query": [{"ch1": {"P": [0]}}],
             },
         ],
     )

--- a/tests/1D_spectrum_tests/test_coupling_freq_contrib.py
+++ b/tests/1D_spectrum_tests/test_coupling_freq_contrib.py
@@ -10,6 +10,9 @@ from mrsimulator.method import SpectralDimension
 from mrsimulator.method import SpectralEvent
 from mrsimulator.spin_system.tensors import SymmetricTensor
 
+positive_sq_tq = [{"ch1": {"P": [1]}}]
+negative_sq_tq = [{"ch1": {"P": [-1]}}]
+
 
 def coupled_spin_system(j_coup=0, dipole=0):
     S1 = Site(
@@ -35,11 +38,9 @@ def hahn_method():
                 count=512,
                 spectral_width=2e4,  # in Hz
                 events=[
-                    SpectralEvent(fraction=0.5, transition_query=[{"ch1": {"P": [1]}}]),
+                    SpectralEvent(fraction=0.5, transition_query=positive_sq_tq),
                     MixingEvent(query={"ch1": {"angle": np.pi, "phase": 0}}),
-                    SpectralEvent(
-                        fraction=0.5, transition_query=[{"ch1": {"P": [-1]}}]
-                    ),
+                    SpectralEvent(fraction=0.5, transition_query=negative_sq_tq),
                 ],
             )
         ],
@@ -61,7 +62,9 @@ def contrib_method(contrib):
             SpectralDimension(
                 count=512,
                 spectral_width=2e4,
-                events=[SpectralEvent(freq_contrib=contrib)],
+                events=[
+                    SpectralEvent(freq_contrib=contrib, transition_query=negative_sq_tq)
+                ],
             )
         ],
     )

--- a/tests/2D_spectrum_tests/test_ssb.py
+++ b/tests/2D_spectrum_tests/test_ssb.py
@@ -30,6 +30,7 @@ def SSB2D_setup(ist, vr, method_type):
     spin_systems = [SpinSystem(sites=[s]) for s in sites]
 
     B0 = 11.7
+    sq_tq = {"transition_query": [{"ch1": {"P": [-1]}}]}
     if method_type == "PASS":
         method = SSB2D(
             channels=[ist],
@@ -60,7 +61,7 @@ def SSB2D_setup(ist, vr, method_type):
                     "count": 64,
                     "spectral_width": 8e4,  # in Hz
                     "label": "Anisotropic dimension",
-                    "events": [{"rotor_angle": 90 * 3.14159 / 180}],
+                    "events": [{"rotor_angle": 90 * 3.14159 / 180, **sq_tq}],
                 },
                 # The last spectral dimension block is the direct-dimension
                 {
@@ -68,7 +69,7 @@ def SSB2D_setup(ist, vr, method_type):
                     "spectral_width": 2e4,  # in Hz
                     "reference_offset": 5e3,  # in Hz
                     "label": "Fast MAS dimension",
-                    "events": [{}],
+                    "events": [sq_tq],
                 },
             ],
             affine_matrix=[[1, -1], [0, 1]],

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -19,7 +19,12 @@ def pre_setup(isotope, shift, reference_offset):
                     "count": 2048,
                     "spectral_width": "25 kHz",
                     "reference_offset": f"{reference_offset} Hz",
-                    "events": [{"magnetic_flux_density": "9.4 T"}],
+                    "events": [
+                        {
+                            "magnetic_flux_density": "9.4 T",
+                            "transition_query": [{"ch1": {"P": [-1]}}],
+                        }
+                    ],
                 }
             ],
         )


### PR DESCRIPTION
- Bug fix for symmetry query involving coupled quadrupolar sites.
- Set default `P` symmetry to `0` for all channels.