### PR TITLE
Larmor frequency helper function

### DIFF
--- a/src/mrsimulator/spin_system/isotope.py
+++ b/src/mrsimulator/spin_system/isotope.py
@@ -86,6 +86,23 @@ class Isotope(BaseModel):
         isotope_data = get_isotope_data(self.symbol)
         return isotope_data["atomic_number"]
 
+    def larmor_freq(self, B0=9.4):
+        """Return the Larmor frequency of the isotope at a magnetic field strength B0.
+
+        Args:
+            float B0: magnetic field strength in T
+
+        Returns:
+            float: larmor frequency in MHz
+
+        Example
+        -------
+
+        >>> silicon = Isotope(symbol="29Si")
+        >>> silicon.larmor_freq(B0 = 9.4)
+        """
+        return -self.gyromagnetic_ratio * B0
+
 
 def format_isotope_string(isotope_string: str) -> str:
     """Format the isotope string to {A}{symbol}, where A is the isotope number."""

--- a/src/mrsimulator/spin_system/isotope.py
+++ b/src/mrsimulator/spin_system/isotope.py
@@ -99,7 +99,7 @@ class Isotope(BaseModel):
         -------
 
         >>> silicon = Isotope(symbol="29Si")
-        >>> silicon.larmor_freq(B0 = 9.4)
+        >>> freq = silicon.larmor_freq(B0 = 9.4)
         """
         return -self.gyromagnetic_ratio * B0
 

--- a/src/mrsimulator/spin_system/tests/test_isotope.py
+++ b/src/mrsimulator/spin_system/tests/test_isotope.py
@@ -15,6 +15,7 @@ def test_isotope():
     assert silicon.natural_abundance == 4.683
     assert silicon.quadrupole_moment == 0.0
     assert silicon.spin == 0.5
+    assert silicon.larmor_freq(B0=11.75) == 99.46962016339306
 
     proton = Isotope(symbol="1H")
     assert proton.atomic_number == 1
@@ -22,6 +23,7 @@ def test_isotope():
     assert proton.natural_abundance == 99.985
     assert proton.quadrupole_moment == 0.0
     assert proton.spin == 0.5
+    assert proton.larmor_freq(B0=9.40) == -400.2283045725638
 
     nitrogen = Isotope(symbol="14N")
     assert nitrogen.atomic_number == 7
@@ -29,6 +31,7 @@ def test_isotope():
     assert nitrogen.natural_abundance == 99.634
     assert nitrogen.quadrupole_moment == 0.0193
     assert nitrogen.spin == 1
+    assert nitrogen.larmor_freq(B0=18.79) == -57.830093199115574
 
     with pytest.raises(Exception, match="Could not parse isotope string"):
         Isotope(symbol="x")


### PR DESCRIPTION
added Larmor_freq function to the Isotope class. Function used to obtain the Larmor frequency (MHz) of an isotope at a specific field strength (T)

Closes issue #185 