### PR TITLE
Attribute and class renames for v0.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -84,6 +84,8 @@ Please review these changes and make changes according.
   Use `SignalProcessor.apply_operations(dataset=...)`
 - The `transition_query` attribute of the `mrsimulator.method.SpectralEvent` class
   is renamed to `transition_queries`.
+- The `mrsimulator.method.query.RotationalQuery` class is renamed to
+  `mrsimulator.method.query.RotationQuery`
 
 **For advanced users**
 - Complete redesign of the `TransitionQuery` object. Please refer to the documentation for details.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,37 +8,37 @@ What's new
 
 - Support for complex amplitude simulation.
 - New isotropic interpolation schemes. Added `isotropic_interpolation` as a `sim.config` parameter.
- Allowed values are `linear` and `Gaussian`.
+  Allowed values are `linear` and `Gaussian`.
 - New `larmor_freq(B0)` function added to the `Isotope` class which returns the Larmor frequency
- of the isotope, given a magnetic flux density. For example, `H1.larmor_freq(B0=9.40)`
+  of the isotope, given a magnetic flux density. For example, `H1.larmor_freq(B0=9.40)`
 - New weak J and dipolar coupling enumerations added to `freq_contrib`.
 - New command-line interface (CLI) tools for mrsimulator.
-- Added 200+ NMR active isotopes to the library. 
+- Added 200+ NMR active isotopes to the library.
 - Support for python 3.10
 
 **Method**
 
 - New Event classes---``SpectralEvent`` and ``MixingEvent``. The MixingEvent controls the transition
- amplitude mixing in a multi-event method.
+  amplitude mixing in a multi-event method.
 - New ``TotalMixing`` and ``NoMixing`` mixing query enumerations for quick scripting of common mixing
- events.
+  events.
 - New weights attribute for the ``TransitionPathway`` object, which holds the probability of
- the transition pathway based on the mixing events defined within the method.
+  the transition pathway based on the mixing events defined within the method.
 - New ``plot()`` function in Method class, which generates a visual representation of the method's events,
- transition pathways, rotor angle, etc.
+  transition pathways, rotor angle, etc.
 - Support for concurrent mixing events.
 - Support for negative spectral width in a spectral dimension.
 - Deprecated ``Method1D`` and ``Method2D`` classes. Use the generic ``mrsimulator.method.Method``
- object for custom 1D and 2D methods.
+  object for custom 1D and 2D methods.
 
 **SpinSystem**
 
 - New function ``simplify()`` to simplifies a spin system object to
- a list of irreducible spin systems.
+  a list of irreducible spin systems.
 - New function ``site_generator()`` added to the utility collection sub-module, which simplifies
- the process of creating Site objects in bulk.
+  the process of creating Site objects in bulk.
 - Added gyromagnetic ratio and quadrupole moment metadata for all isotopes, including unstable
- isotopes.
+  isotopes.
 
 **SignalProcessor**
 
@@ -80,11 +80,13 @@ Please review these changes and make changes according.
 
 - The `mrsimulator.methods` module is renamed as `mrsimulator.method.lib`.
 - The `mrsimulator.signal_processing` module is renamed to `mrsimulator.signal_processor`.
-- The `data` attribute of `SignalProcessor.apply_operations(data=...)` is rename to `dataset`.
- Use `SignalProcessor.apply_operations(dataset=...)`
+- The `data` attribute of `SignalProcessor.apply_operations(data=...)` is renamed to `dataset`.
+  Use `SignalProcessor.apply_operations(dataset=...)`
+- The `transition_query` attribute of the `mrsimulator.method.SpectralEvent` class
+  is renamed to `transition_queries`.
 
 **For advanced users**
-- Complete redesign of the `TransitionQuery` object. Please refer to the documentation for details. 
+- Complete redesign of the `TransitionQuery` object. Please refer to the documentation for details.
 
 
 v0.6.0

--- a/docs/api_py/method/query.rst
+++ b/docs/api_py/method/query.rst
@@ -22,7 +22,7 @@ Query objects
     :members:
     :inherited-members: BaseModel
 
-.. autoclass:: RotationalQuery
+.. autoclass:: RotationQuery
     :show-inheritance:
     :members:
     :inherited-members: BaseModel

--- a/docs/api_py/methods/BlochDecayCTSpectrum.rst
+++ b/docs/api_py/methods/BlochDecayCTSpectrum.rst
@@ -41,7 +41,7 @@ but can be constructed with a generic method as follows
     ...             "count": 1024,
     ...             "spectral_width": 50000,  # in Hz
     ...             "reference_offset": -8000,  # in Hz
-    ...             "events": [{"transition_query": [{"ch1": {"P": [-1], "D": [0]}}]}],
+    ...             "events": [{"transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]}],
     ...         }
     ...     ],
     ... )

--- a/docs/api_py/methods/BlochDecaySpectrum.rst
+++ b/docs/api_py/methods/BlochDecaySpectrum.rst
@@ -42,7 +42,7 @@ but can be constructed with a generic method as follows
     ...             "count": 1024,
     ...             "spectral_width": 50000,  # in Hz
     ...             "reference_offset": -8000,  # in Hz
-    ...             "events": [{"transition_query": [{"ch1": {"P": [-1]}}]}],
+    ...             "events": [{"transition_queries": [{"ch1": {"P": [-1]}}]}],
     ...         }
     ...     ],
     ... )

--- a/docs/user_guide/io/mrsim_IO.rst
+++ b/docs/user_guide/io/mrsim_IO.rst
@@ -157,12 +157,12 @@ custom DAS method and serialize it to a file using the method
                     SpectralEvent(
                         fraction=0.5,
                         rotor_angle=37.38 * 3.14159 / 180,
-                        transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                        transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                     ),
                     SpectralEvent(
                         fraction=0.5,
                         rotor_angle=79.19 * 3.14159 / 180,
-                        transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                        transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                     ),
                 ],
             ),
@@ -176,7 +176,7 @@ custom DAS method and serialize it to a file using the method
                 events=[
                     SpectralEvent(
                         rotor_angle=54.735 * 3.14159 / 180,
-                        transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                        transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                     )
                 ],
             ),

--- a/docs/user_guide/method/method.rst
+++ b/docs/user_guide/method/method.rst
@@ -138,7 +138,7 @@ explicit **MixingEvent** object between such events. Inside **MixingEvent**
 objects is a :py:meth:`~mrsimulator.method.query.MixingQuery` object, which
 determines the coherence transfer amplitude between transitions. A
 **MixingQuery** object holds
-:py:meth:`~mrsimulator.method.query.RotationalQuery` objects acting on specific
+:py:meth:`~mrsimulator.method.query.RotationQuery` objects acting on specific
 isotopes in the spin system. As before, the isotope upon which the
 **RotationQuery** objects act is determined by the ``channels`` attribute in the
 **Method** object.
@@ -1599,9 +1599,9 @@ illustrated in the sample code below.
     :context: close-figs
 
     import numpy as np
-    from mrsimulator.method.query import RotationalQuery
-    rot_query_90 = RotationalQuery(angle=np.pi/2, phase=0)
-    rot_query_180 = RotationalQuery(angle=np.pi, phase=0)
+    from mrsimulator.method.query import RotationQuery
+    rot_query_90 = RotationQuery(angle=np.pi/2, phase=0)
+    rot_query_180 = RotationQuery(angle=np.pi, phase=0)
     rot_mixing = MixingEvent(query={
             "ch1": rot_query_90,
             "ch2": rot_query_180

--- a/docs/user_guide/method/method.rst
+++ b/docs/user_guide/method/method.rst
@@ -300,7 +300,7 @@ as defined in the code below.
 
     symm_query = SymmetryQuery(P=[-1], D=[1])
     trans_query = TransitionQuery(ch1=symm_query)
-    spec_event = SpectralEvent(transition_query=[trans_query])
+    spec_event = SpectralEvent(transition_queries=[trans_query])
 
 .. note::
     Python dictionaries can also be used to create and initialize **mrsimulator** objects.
@@ -316,7 +316,7 @@ as defined in the code below.
             trans_query_dict = {"ch1": symm_query_dict}
 
             # Dictionary of TransitionQuery passed to SpectralEvent
-            spec_event = SpectralEvent(transition_query=[trans_query_dict])
+            spec_event = SpectralEvent(transition_queries=[trans_query_dict])
 
 In the example above, the **SymmetryQuery** object is created and assigned to
 the **TransitionQuery** attribute ``ch1``, i.e., it acts on the isotope in the
@@ -358,7 +358,7 @@ below.
             SpectralDimension(
                 count=512,
                 spectral_width=40000,  # in Hz
-                events=[SpectralEvent(transition_query=[{"ch1": {"P": [-1]}}])],
+                events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-1]}}])],
             )
         ],
     )
@@ -371,7 +371,7 @@ below.
             SpectralDimension(
                 count=512,
                 spectral_width=40000,  # in Hz
-                events=[SpectralEvent(transition_query=[{"ch1": {"P": [-1], "D": [1]}}])],
+                events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-1], "D": [1]}}])],
             )
         ],
     )
@@ -384,7 +384,7 @@ below.
             SpectralDimension(
                 count=512,
                 spectral_width=40000,  # in Hz
-                events=[SpectralEvent(transition_query=[{"ch1": {"P": [-1], "D": [-1]}}])],
+                events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-1], "D": [-1]}}])],
             )
         ],
     )
@@ -467,14 +467,14 @@ transition.   The code below is an example of a custom 2D method using two
                 spectral_width=6e3,  # in Hz
                 reference_offset=-9e3,  # in Hz
                 label="Symmetric 3Q Frequency",
-                events=[SpectralEvent(transition_query=[{"ch1": {"P": [-3], "D": [0]}}])],
+                events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-3], "D": [0]}}])],
             ),
             SpectralDimension(
                 count=256,
                 spectral_width=6e3,  # in Hz
                 reference_offset=-5e3,  # in Hz
                 label="Central Transition Frequency",
-                events=[SpectralEvent(transition_query=[{"ch1": {"P": [-1], "D": [0]}}])],
+                events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-1], "D": [0]}}])],
             ),
         ],
     )
@@ -675,7 +675,7 @@ is given in the code below.
                 spectral_width=1800,  # in Hz
                 reference_offset=1000,  # in Hz
                 label="$^{1}$H frequency",
-                events=[SpectralEvent(transition_query=[{"ch1": {"P": [-1]}}])],
+                events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-1]}}])],
             )
         ],
     )
@@ -806,7 +806,7 @@ The code below will select the six *two-spin double-quantum transitions* where
                 spectral_width=2000,  # in Hz
                 reference_offset=2000,  # in Hz
                 label="$^{1}$H frequency",
-                events=[SpectralEvent(transition_query=[{"ch1": {"P": [-1, -1]}}])],
+                events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-1, -1]}}])],
             )
         ],
     )
@@ -913,7 +913,7 @@ The code below will select these *three-spin single-quantum transitions*.
                 spectral_width=4000,  # in Hz
                 reference_offset=1000,  # in Hz
                 label="$^{1}$H frequency",
-                events=[SpectralEvent(transition_query=[{"ch1": {"P": [-1, -1, +1]}}])]
+                events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-1, -1, +1]}}])]
             )
         ],
     )
@@ -1031,7 +1031,7 @@ the right.
                 spectral_width=200000,  # in Hz
                 reference_offset=0,  # in Hz
                 label="$^{2}$H frequency",
-                events=[SpectralEvent(transition_query=[{"ch1": {"P": [-1]}}])],
+                events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-1]}}])],
             )
         ],
     )
@@ -1045,7 +1045,7 @@ the right.
                 spectral_width=200000,  # in Hz
                 reference_offset=0,  # in Hz
                 label="$^{2}$H frequency",
-                events=[SpectralEvent(transition_query=[{"ch1": {"P": [-1], "D": [-1]}}])],
+                events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-1], "D": [-1]}}])],
             )
         ],
     )
@@ -1061,7 +1061,7 @@ the right.
                 label="$^{2}$H frequency",
                 events=[
                     SpectralEvent(
-                        transition_query=[{"ch1": {"P": [-2]}, "ch2": {"P": [-1]}}]
+                        transition_queries=[{"ch1": {"P": [-2]}, "ch2": {"P": [-1]}}]
                     )
                 ],
             )
@@ -1246,7 +1246,7 @@ affine matrix to perform this shear transformation.
                 reference_offset=-9e3,  # in Hz
                 label="3Q-MAS isotropic dimension",
                 events=[
-                    SpectralEvent(transition_query=[{"ch1": {"P": [-3], "D": [0]}}])
+                    SpectralEvent(transition_queries=[{"ch1": {"P": [-3], "D": [0]}}])
                 ],
             ),
             SpectralDimension(
@@ -1255,7 +1255,7 @@ affine matrix to perform this shear transformation.
                 reference_offset=-5e3,  # in Hz
                 label="Central Transition Frequency",
                 events=[
-                    SpectralEvent(transition_query=[{"ch1": {"P": [-1], "D": [0]}}])
+                    SpectralEvent(transition_queries=[{"ch1": {"P": [-1], "D": [0]}}])
                 ],
             ),
         ],
@@ -1346,7 +1346,7 @@ Below is the code for simulating a 3Q-MAS spectrum with a double shear transform
                 reference_offset=-9e3,  # in Hz
                 label="3Q-MAS isotropic dimension",
                 events=[
-                    SpectralEvent(transition_query=[{"ch1": {"P": [-3], "D": [0]}}])
+                    SpectralEvent(transition_queries=[{"ch1": {"P": [-3], "D": [0]}}])
                 ],
             ),
             SpectralDimension(
@@ -1355,7 +1355,7 @@ Below is the code for simulating a 3Q-MAS spectrum with a double shear transform
                 reference_offset=0,  # in Hz
                 label="CT Quad-Only Frequency",
                 events=[
-                    SpectralEvent(transition_query=[{"ch1": {"P": [-1], "D": [0]}}])
+                    SpectralEvent(transition_queries=[{"ch1": {"P": [-1], "D": [0]}}])
                 ],
             ),
         ],
@@ -1417,10 +1417,10 @@ code below.
                 label="3Q-MAS isotropic dimension",
                 events=[
                     SpectralEvent(
-                        fraction=9 / 16, transition_query=[{"ch1": {"P": [-3], "D": [0]}}]
+                        fraction=9 / 16, transition_queries=[{"ch1": {"P": [-3], "D": [0]}}]
                     ),
                     SpectralEvent(
-                        fraction=7 / 16, transition_query=[{"ch1": {"P": [-1], "D": [0]}}]
+                        fraction=7 / 16, transition_queries=[{"ch1": {"P": [-1], "D": [0]}}]
                     ),
                 ],
             ),
@@ -1430,7 +1430,7 @@ code below.
                 reference_offset=-5e3,  # in Hz
                 label="Central Transition Frequency",
                 events=[
-                    SpectralEvent(transition_query=[{"ch1": {"P": [-1], "D": [0]}}])
+                    SpectralEvent(transition_queries=[{"ch1": {"P": [-1], "D": [0]}}])
                 ],
             ),
         ],
@@ -1514,9 +1514,9 @@ below.
     from mrsimulator.method import MixingEvent
 
     events = [
-        SpectralEvent(fraction=9 / 16, transition_query=[{"ch1": {"P": [-3], "D": [0]}}]),
+        SpectralEvent(fraction=9 / 16, transition_queries=[{"ch1": {"P": [-3], "D": [0]}}]),
         MixingEvent(query="TotalMixing"),
-        SpectralEvent(fraction=7 / 16, transition_query=[{"ch1": {"P": [-1], "D": [0]}}]),
+        SpectralEvent(fraction=7 / 16, transition_queries=[{"ch1": {"P": [-1], "D": [0]}}]),
         MixingEvent(query="TotalMixing"),
     ]
 
@@ -1867,7 +1867,7 @@ We use the deuterium Site defined earlier in this document.
                 events=[
                     SpectralEvent(
                         fraction=0.5,
-                        transition_query=[
+                        transition_queries=[
                             {"ch1": {"P": [1], "D": [1]}},
                             {"ch1": {"P": [1], "D": [-1]}},
                         ],
@@ -1875,7 +1875,7 @@ We use the deuterium Site defined earlier in this document.
                     MixingEvent(query={"ch1": {"angle": 3.141592, "phase": 0}}),
                     SpectralEvent(
                         fraction=0.5,
-                        transition_query=[
+                        transition_queries=[
                             {"ch1": {"P": [-1], "D": [1]}},
                             {"ch1": {"P": [-1], "D": [-1]}},
                         ],
@@ -1895,7 +1895,7 @@ We use the deuterium Site defined earlier in this document.
                 events=[
                     SpectralEvent(
                         fraction=0.5,
-                        transition_query=[
+                        transition_queries=[
                             {"ch1": {"P": [-1], "D": [1]}},
                             {"ch1": {"P": [-1], "D": [-1]}},
                         ],
@@ -1903,7 +1903,7 @@ We use the deuterium Site defined earlier in this document.
                     MixingEvent(query={"ch1": {"angle": 3.141592 / 2, "phase": 0}}),
                     SpectralEvent(
                         fraction=0.5,
-                        transition_query=[
+                        transition_queries=[
                             {"ch1": {"P": [-1], "D": [1]}},
                             {"ch1": {"P": [-1], "D": [-1]}},
                         ],
@@ -2021,7 +2021,7 @@ is illustrated below.
                 spectral_width=2e4,  # in Hz
                 events=[
                     SpectralEvent(
-                        transition_query=[{"ch1": {"P": [-1]}}],
+                        transition_queries=[{"ch1": {"P": [-1]}}],
                         freq_contrib=["Quad1_2"]
                     )
                 ],
@@ -2038,7 +2038,7 @@ is illustrated below.
                 spectral_width=2e4,  # in Hz
                 events=[
                     SpectralEvent(
-                        transition_query=[{"ch1": {"P": [-1]}}],
+                        transition_queries=[{"ch1": {"P": [-1]}}],
                         freq_contrib=["Shielding1_0", "Shielding1_2"],
                     )
                 ],
@@ -2235,7 +2235,7 @@ Attribute Summaries
       ``["Shielding1_0", "Shielding1_2"]``. By default, the list is all frequency enumerations and
       all frequency contributions are calculated.
 
-  * - transition_query
+  * - transition_queries
     - ``list``
     - An *optional* ``list`` of :ref:`transition_api` objects, or their ``dict`` representations
       selecting transitions active during the event. Only these selected transitions will

--- a/docs/user_guide/method/query_objects.rst
+++ b/docs/user_guide/method/query_objects.rst
@@ -187,5 +187,5 @@ follows,
     }
 
 where ``ch-`` s are the channels over which the query is performed. Its value is the
-python dictionary representation of the :class:`~mrsimulator.method.query.RotationalQuery`
+python dictionary representation of the :class:`~mrsimulator.method.query.RotationQuery`
 object. A MixingQuery is a channel-wise selective rotation with parameters `angle` and `phase`.

--- a/docs/user_guide/method/query_objects.rst
+++ b/docs/user_guide/method/query_objects.rst
@@ -12,7 +12,7 @@ transition pathways---pathways that satisfy the mixing query criterion.
 TransitionQuery
 ---------------
 
-Transition queries are assigned to the `transition_query` attribute of a SpectralEvent
+Transition queries are assigned to the `transition_queries` attribute of a SpectralEvent
 object as
 
 .. code-block:: python
@@ -21,7 +21,7 @@ object as
 
     SpectralEvent(
         # other attributes
-        transition_query=[
+        transition_queries=[
             # list of TransitionQuery objects
         ]
     )
@@ -143,13 +143,13 @@ common to all selection criteria.
 Now consider a case where we want to select both :math:`p=-1`` and :math:`p=+1`` transitions
 simultaneously. Following the rule of intersection, there are precisely zero transitions that
 are both :math:`p=+1` and :math:`p=-1`. Here, we use the **union** rule. Recall that the
-value of the `transition_query` attribute of the SpectralEvent object is a list of queries,
+value of the `transition_queries` attribute of the SpectralEvent object is a list of queries,
 
 .. code-block:: python
 
     SpectralEvent(
         # other attributes
-        transition_query=[
+        transition_queries=[
             # TransitionQuery(...),  # 0
             # TransitionQuery(...),  # 1
             # TransitionQuery(...),  # 2
@@ -164,7 +164,7 @@ three queries. To select :math:`p=\pm1` transitions, we write
 
     SpectralEvent(
         # other attributes
-        transition_query=[
+        transition_queries=[
             # union of set of transitions from query-1 and query-2
             {"ch1": {"P": [-1]}},  # query-1
             {"ch1": {"P": [+1]}},  # query-2

--- a/examples_source/1D_simulation(crystalline)/plot_4_satellite_transition_sim.py
+++ b/examples_source/1D_simulation(crystalline)/plot_4_satellite_transition_sim.py
@@ -39,9 +39,9 @@ spin_system = SpinSystem(sites=[site])
 # :ref:`spectral_dim_api` object in Method contains additional argument---`events`.
 #
 # The :ref:`event_api` object is a collection of attributes, which are local to the
-# event. It is here where we define a `transition_query` to select one or more
-# transitions for simulating the spectrum. The two attributes of the `transition_query`
-# are `P` and `D`, which are given as,
+# event. It is here where we define a `transition_queries` to select one or more
+# transitions for simulating the spectrum. The two attributes of the
+# `transition_queries` are `P` and `D`, which are given as,
 #
 # .. math::
 #     P &= m_f - m_i \\
@@ -72,7 +72,7 @@ method = Method(
             events=[
                 SpectralEvent(
                     # Selecting the inner satellite transitions
-                    transition_query=[{"ch1": {"P": [-1], "D": [2]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [2]}}],
                 )
             ],
         )
@@ -122,7 +122,7 @@ method2 = Method(
             reference_offset=1e4,  # in Hz
             events=[
                 SpectralEvent(
-                    transition_query=[
+                    transition_queries=[
                         # select inter satellite transitions
                         {"ch1": {"P": [-1], "D": [2]}},
                         # select outer satellite transitions

--- a/examples_source/1D_simulation(crystalline)/plot_5_multi-quantum_spectrum.py
+++ b/examples_source/1D_simulation(crystalline)/plot_5_multi-quantum_spectrum.py
@@ -37,7 +37,8 @@ spin_system = SpinSystem(sites=[site])
 # - :math:`|5/2\rangle\rightarrow|-1/2\rangle` (:math:`P=-3, D=-6`)
 #
 # To select one or more triple-quantum transitions, assign the respective value of P and
-# D to the `transition_query`. Here, we select the symmetric triple-quantum transition.
+# D to the `transition_queries`. Here, we select the symmetric triple-quantum
+# transition.
 method = Method(
     name="Arbitrary Transition Method",
     channels=["27Al"],
@@ -51,7 +52,7 @@ method = Method(
             events=[
                 SpectralEvent(
                     # symmetric triple quantum transitions
-                    transition_query=[{"ch1": {"P": [-3], "D": [0]}}]
+                    transition_queries=[{"ch1": {"P": [-3], "D": [0]}}]
                 ),
             ],
         )

--- a/examples_source/1D_simulation(crystalline)/plot_9_custom_method_Hahnecho.py
+++ b/examples_source/1D_simulation(crystalline)/plot_9_custom_method_Hahnecho.py
@@ -62,14 +62,15 @@ spin_system_2 = SpinSystem(sites=[S1, S2], couplings=[S12], label="Coupled syste
 #       p = 1 \rightarrow -1.
 #
 # In the following code, we define the two SpectralEvent objects with fraction 0.5 and
-# the transition_query on channel-1 of P=[1] and P=[-1], respectively. Notice, the value
-# for the ``P`` attribute is a list. Here, it is a list with a single integer. The list
-# notation, ``[1]``, implies that the query selects all transitions where exactly one
-# spin is undergoing a :math:`p=+1` transition with the remaining spin at :math:`p=0`.
-# A similar argument holds for ``[-1]`` query. By implementing query objects, we
-# decouple the method from the spin system, i.e., once a method is defined, it can be
-# used to simulate spectra from any given spin system. We will demonstrate this
-# momentarily by simulating a Hahn echo spectrum from single and two-site spin systems.
+# the transition_queries on channel-1 of P=[1] and P=[-1], respectively. Notice, the
+# value for the ``P`` attribute is a list. Here, it is a list with a single integer. The
+# list notation, ``[1]``, implies that the query selects all transitions where exactly
+# one spin is undergoing a :math:`p=+1` transition with the remaining spin at
+# :math:`p=0`. A similar argument holds for ``[-1]`` query. By implementing query
+# objects, we decouple the method from the spin system, i.e., once a method is defined,
+# it can be used to simulate spectra from any given spin system. We will demonstrate
+# this momentarily by simulating a Hahn echo spectrum from single and two-site spin
+# systems.
 #
 # Besides the SpectralEvent, you may also notice a MixingEvent sandwiched in-between
 # the two SpectralEvent. A MixingEvent does not directly contribute to the frequencies.
@@ -85,9 +86,9 @@ hahn_echo = Method(
             count=512,
             spectral_width=2e4,  # in Hz
             events=[
-                SpectralEvent(fraction=0.5, transition_query=[{"ch1": {"P": [1]}}]),
+                SpectralEvent(fraction=0.5, transition_queries=[{"ch1": {"P": [1]}}]),
                 MixingEvent(query={"ch1": {"angle": np.pi, "phase": 0}}),
-                SpectralEvent(fraction=0.5, transition_query=[{"ch1": {"P": [-1]}}]),
+                SpectralEvent(fraction=0.5, transition_queries=[{"ch1": {"P": [-1]}}]),
             ],
         )
     ],

--- a/examples_source/2D_simulation(crystalline)/plot_2_SAS_Rb2SO4.py
+++ b/examples_source/2D_simulation(crystalline)/plot_2_SAS_Rb2SO4.py
@@ -52,7 +52,7 @@ sas = Method(
             events=[
                 SpectralEvent(
                     rotor_angle=90 * 3.14159 / 180,  # in radians
-                    transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                 )
             ],
         ),
@@ -64,7 +64,7 @@ sas = Method(
             events=[
                 SpectralEvent(
                     rotor_angle=54.74 * 3.14159 / 180,  # in radians
-                    transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                 )
             ],
         ),

--- a/examples_source/2D_simulation(crystalline)/plot_3_SAS_Rb2CrO4.py
+++ b/examples_source/2D_simulation(crystalline)/plot_3_SAS_Rb2CrO4.py
@@ -53,7 +53,7 @@ sas = Method(
             events=[
                 SpectralEvent(
                     rotor_angle=70.12 * 3.14159 / 180,  # in radians
-                    transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                 )
             ],
         ),
@@ -65,7 +65,7 @@ sas = Method(
             events=[
                 SpectralEvent(
                     rotor_angle=54.74 * 3.14159 / 180,  # in radians
-                    transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                 )
             ],
         ),

--- a/examples_source/2D_simulation(crystalline)/plot_4_DAS_Coesite.py
+++ b/examples_source/2D_simulation(crystalline)/plot_4_DAS_Coesite.py
@@ -44,12 +44,12 @@ das = Method(
                 SpectralEvent(
                     fraction=0.5,
                     rotor_angle=37.38 * 3.14159 / 180,  # in rads
-                    transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                 ),
                 SpectralEvent(
                     fraction=0.5,
                     rotor_angle=79.19 * 3.14159 / 180,  # in rads
-                    transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                 ),
             ],
         ),
@@ -62,7 +62,7 @@ das = Method(
             events=[
                 SpectralEvent(
                     rotor_angle=54.735 * 3.14159 / 180,  # in rads
-                    transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                 )
             ],
         ),

--- a/examples_source/2D_simulation(crystalline)/plot_5_COASTER_Rb2CrO4.py
+++ b/examples_source/2D_simulation(crystalline)/plot_5_COASTER_Rb2CrO4.py
@@ -58,7 +58,7 @@ coaster = Method(
             reference_offset=-8e3,  # in Hz
             label="$\\omega_1$ (CSA)",
             events=[
-                SpectralEvent(transition_query=[{"ch1": {"P": [3], "D": [0]}}]),
+                SpectralEvent(transition_queries=[{"ch1": {"P": [3], "D": [0]}}]),
                 MixingEvent(query={"ch1": {"angle": np.pi * 109.5 / 180, "phase": 0}}),
             ],
         ),
@@ -68,7 +68,7 @@ coaster = Method(
             spectral_width=8e3,  # in Hz
             reference_offset=-4e3,  # in Hz
             label="$\\omega_2$ (Q)",
-            events=[SpectralEvent(transition_query=[{"ch1": {"P": [-1], "D": [0]}}])],
+            events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-1], "D": [0]}}])],
         ),
     ],
     affine_matrix=[[1, 0], [1 / 4, 3 / 4]],

--- a/examples_source/2D_simulation(crystalline)/plot_8_MAF.py
+++ b/examples_source/2D_simulation(crystalline)/plot_8_MAF.py
@@ -65,7 +65,7 @@ maf = Method(
             events=[
                 SpectralEvent(
                     rotor_angle=90 * 3.14159 / 180,  # in rads
-                    transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                 ),
                 MixingEvent(query="NoMixing"),
             ],
@@ -78,7 +78,7 @@ maf = Method(
             events=[
                 SpectralEvent(
                     rotor_angle=54.735 * 3.14159 / 180,  # in rads
-                    transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                 )
             ],
         ),

--- a/examples_source/2D_simulation(crystalline)/plot_9_shifting-d.py
+++ b/examples_source/2D_simulation(crystalline)/plot_9_shifting-d.py
@@ -125,7 +125,7 @@ shifting_d = Method(
             label="Quadrupolar frequency",
             events=[
                 SpectralEvent(
-                    transition_query=[{"ch1": {"P": [-1]}}],
+                    transition_queries=[{"ch1": {"P": [-1]}}],
                     freq_contrib=["Quad1_2"],
                 ),
                 MixingEvent(query="NoMixing"),
@@ -138,7 +138,7 @@ shifting_d = Method(
             label="Paramagnetic shift",
             events=[
                 SpectralEvent(
-                    transition_query=[{"ch1": {"P": [-1]}}],
+                    transition_queries=[{"ch1": {"P": [-1]}}],
                     freq_contrib=["Shielding1_0", "Shielding1_2"],
                 )
             ],

--- a/fitting_source/2D_fitting/plot_2_Coesite_DAS.py
+++ b/fitting_source/2D_fitting/plot_2_Coesite_DAS.py
@@ -90,13 +90,13 @@ DAS = Method(
                 SpectralEvent(
                     fraction=0.5,
                     rotor_angle=37.38 * 3.14159 / 180,  # in rads
-                    transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                 ),
                 MixingEvent(query="NoMixing"),
                 SpectralEvent(
                     fraction=0.5,
                     rotor_angle=79.19 * 3.14159 / 180,  # in rads
-                    transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                 ),
                 MixingEvent(query="NoMixing"),
             ],
@@ -107,7 +107,7 @@ DAS = Method(
             events=[
                 SpectralEvent(
                     rotor_angle=54.735 * 3.14159 / 180,  # in rads
-                    transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                    transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                 )
             ],
         ),

--- a/fitting_source/2D_fitting/plot_4_NiCl2.2D2O_shifting-d.py
+++ b/fitting_source/2D_fitting/plot_4_NiCl2.2D2O_shifting-d.py
@@ -102,7 +102,7 @@ shifting_d = Method(
             label="Quadrupolar frequency",
             events=[
                 SpectralEvent(
-                    transition_query=[{"ch1": {"P": [-1]}}],
+                    transition_queries=[{"ch1": {"P": [-1]}}],
                     freq_contrib=["Quad1_2"],
                 ),
                 MixingEvent(query="NoMixing"),
@@ -113,7 +113,7 @@ shifting_d = Method(
             label="Paramagnetic shift",
             events=[
                 SpectralEvent(
-                    transition_query=[{"ch1": {"P": [-1]}}],
+                    transition_queries=[{"ch1": {"P": [-1]}}],
                     freq_contrib=["Shielding1_0", "Shielding1_2"],
                 )
             ],

--- a/src/mrsimulator/__init__.py
+++ b/src/mrsimulator/__init__.py
@@ -122,7 +122,7 @@ class Mrsimulator(Parseable):
         ...           {
         ...             "count": 1024,
         ...             "spectral_width": "25000.0 Hz",
-        ...             "events": [{ "transition_query": [{ "ch1": { "P": [-1] } }] }]
+        ...             "events": [{ "transition_queries": [{ "ch1": { "P": [-1] } }] }]
         ...           }
         ...         ],
         ...         "magnetic_flux_density": "9.4 T",

--- a/src/mrsimulator/benchmark.py
+++ b/src/mrsimulator/benchmark.py
@@ -118,13 +118,13 @@ def quad_static_2d_method():
                 "count": 256,
                 "spectral_width": 4e4,  # in Hz
                 "reference_offset": -1e4,  # in Hz
-                "events": [{"rotor_angle": 70.12 * to_rad, "transition_query": tq}],
+                "events": [{"rotor_angle": 70.12 * to_rad, "transition_queries": tq}],
             },
             {
                 "count": 512,
                 "spectral_width": 5e4,  # in Hz
                 "reference_offset": -5e3,  # in Hz
-                "events": [{"rotor_angle": 54.74 * to_rad, "transition_query": tq}],
+                "events": [{"rotor_angle": 54.74 * to_rad, "transition_queries": tq}],
             },
         ],
     )

--- a/src/mrsimulator/method/__init__.py
+++ b/src/mrsimulator/method/__init__.py
@@ -375,17 +375,17 @@ class Method(Parseable):
             ...             "events": [
             ...                 {
             ...                     "fraction": 0.5,
-            ...                     "transition_query": [{"ch1": {"P": [1]}}]
+            ...                     "transition_queries": [{"ch1": {"P": [1]}}]
             ...                 },
             ...                 {
             ...                     "fraction": 0.5,
-            ...                     "transition_query": [{"ch1": {"P": [0]}}]
+            ...                     "transition_queries": [{"ch1": {"P": [0]}}]
             ...                 }
             ...             ],
             ...         },
             ...         {
             ...             "events": [
-            ...                 {"transition_query": [{"ch1": {"P": [-1]}}]},
+            ...                 {"transition_queries": [{"ch1": {"P": [-1]}}]},
             ...             ],
             ...         }
             ...     ]
@@ -406,14 +406,14 @@ class Method(Parseable):
             ...         {
             ...             "events": [{
             ...                 "fraction": 0.5,
-            ...                 "transition_query": [
+            ...                 "transition_queries": [
             ...                     {"ch1": {"P": [1]}},
             ...                     {"ch1": {"P": [-1]}},
             ...                 ]
             ...             },
             ...             {
             ...                 "fraction": 0.5,
-            ...                 "transition_query": [  # selecting double quantum
+            ...                 "transition_queries": [  # selecting double quantum
             ...                     {"ch1": {"P": [-1]}, "ch2": {"P": [-1]}},
             ...                     {"ch1": {"P": [1]}, "ch2": {"P": [1]}},
             ...                 ]
@@ -421,7 +421,7 @@ class Method(Parseable):
             ...         },
             ...         {
             ...             "events": [{
-            ...                 "transition_query": [ # selecting single quantum
+            ...                 "transition_queries": [ # selecting single quantum
             ...                     {"ch1": {"P": [-1]}},
             ...                 ]
             ...             }],

--- a/src/mrsimulator/method/event.py
+++ b/src/mrsimulator/method/event.py
@@ -45,7 +45,7 @@ class BaseEvent(Parseable):
     freq_contrib:
         A list of FrequencyEnum enumeration. The default is all frequency enumerations.
 
-    transition_query:
+    transition_queries:
         A TransitionQuery or an equivalent dict object listing the queries used in
         selecting the active transitions during the event. Only the active transitions
         from this query will contribute to the net frequency.
@@ -55,7 +55,7 @@ class BaseEvent(Parseable):
     rotor_frequency: float = Field(default=None, ge=0.0)
     rotor_angle: float = Field(default=None, ge=0.0, le=1.5707963268)
     freq_contrib: List[FrequencyEnum] = default_freq_contrib
-    transition_query: List[TransitionQuery] = [TransitionQuery()]
+    transition_queries: List[TransitionQuery] = [TransitionQuery()]
 
     property_unit_types: ClassVar[Dict] = {
         "magnetic_flux_density": "magnetic flux density",
@@ -108,7 +108,9 @@ class BaseEvent(Parseable):
             (list) isotopes: List of isotopes in the spin system.
             (list) channels: List of method channels.
         """
-        return [item.combination(isotopes, channels) for item in self.transition_query]
+        return [
+            item.combination(isotopes, channels) for item in self.transition_queries
+        ]
 
     def filter_transitions(self, all_transitions, isotopes, channels):
         """Filter transitions based on the transition query.
@@ -155,7 +157,7 @@ class SpectralEvent(BaseEvent):
     freq_contrib:
         A list of FrequencyEnum enumeration. The default is all frequency enumerations.
 
-    transition_query:
+    transition_queries:
         A TransitionQuery or an equivalent dict object listing the queries used in
         selecting the active transitions during the event. Only the active transitions
         from this query will contribute to the net frequency.
@@ -194,7 +196,7 @@ class ConstantDurationEvent(BaseEvent):  # TransitionModulationEvent
     freq_contrib:
         A list of FrequencyEnum enumeration. The default is all frequency enumerations.
 
-    transition_query:
+    transition_queries:
         A TransitionQuery or an equivalent dict object listing the queries used in
         selecting the active transitions during the event. Only the active transitions
         from this query will contribute to the net frequency.

--- a/src/mrsimulator/method/lib/base.py
+++ b/src/mrsimulator/method/lib/base.py
@@ -166,7 +166,7 @@ class BlochDecaySpectrum(BaseNamedMethod1D):
 
     @classmethod
     def update(cls, **kwargs):
-        events = [{"transition_query": [{"ch1": {"P": [-1]}}]}]
+        events = [{"transition_queries": [{"ch1": {"P": [-1]}}]}]
         return {
             "spectral_dimensions": [{"events": events}],
         }
@@ -185,7 +185,7 @@ class BlochDecayCTSpectrum(BaseNamedMethod1D):
 
     @classmethod
     def update(cls, **kwargs):
-        events = [{"transition_query": [{"ch1": {"P": [-1], "D": [0]}}]}]
+        events = [{"transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]}]
         return {
             "spectral_dimensions": [{"events": events}],
         }

--- a/src/mrsimulator/method/lib/correlation.py
+++ b/src/mrsimulator/method/lib/correlation.py
@@ -75,10 +75,10 @@ class Cosy(BaseNamedMethod2D):
     @classmethod
     def update(self, **kwargs):
         event_0 = [
-            {"transition_query": [{"ch1": {"P": [-1]}}]},
+            {"transition_queries": [{"ch1": {"P": [-1]}}]},
             {"query": {"ch1": {"angle": np.pi / 2}}},
         ]
-        event_1 = [{"transition_query": [{"ch1": {"P": [-1]}}]}]
+        event_1 = [{"transition_queries": [{"ch1": {"P": [-1]}}]}]
 
         return {
             "spectral_dimensions": [{"events": event_0}, {"events": event_1}],
@@ -138,8 +138,8 @@ class Inadequate(BaseNamedMethod2D):
 
     @classmethod
     def update(cls, **kwargs):
-        event_0 = [{"transition_query": [{"ch1": {"P": [-1, -1]}}]}]
-        event_1 = [{"transition_query": [{"ch1": {"P": [-1]}}]}]
+        event_0 = [{"transition_queries": [{"ch1": {"P": [-1, -1]}}]}]
+        event_1 = [{"transition_queries": [{"ch1": {"P": [-1]}}]}]
 
         return {
             "spectral_dimensions": [{"events": event_0}, {"events": event_1}],

--- a/src/mrsimulator/method/lib/mqvas.py
+++ b/src/mrsimulator/method/lib/mqvas.py
@@ -57,9 +57,9 @@ class MQ_VAS(BaseNamedMethod2D):
         P = -P if mq == spin else P
 
         # set transition symmetry elements for spectral dimension 0
-        events_0 = [{"transition_query": [{"ch1": {"P": [P], "D": [0]}}]}]
+        events_0 = [{"transition_queries": [{"ch1": {"P": [P], "D": [0]}}]}]
         # set transition symmetry elements for spectral dimension 1
-        events_1 = [{"transition_query": [{"ch1": {"P": [-1], "D": [0]}}]}]
+        events_1 = [{"transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]}]
 
         # method affine matrix shear factor
         k = shear_factor_MQ_MAS[nQ][spin]

--- a/src/mrsimulator/method/lib/ssb2d.py
+++ b/src/mrsimulator/method/lib/ssb2d.py
@@ -56,12 +56,12 @@ class SSB2D(BaseNamedMethod2D):
     @classmethod
     def update(cls, **kwargs):
         # events for spectral dimension at index 0
-        events_0 = [{"transition_query": [{"ch1": {"P": [-1], "D": [0]}}]}]
+        events_0 = [{"transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]}]
         # events for spectral dimension at index 1
         events_1 = [
             {
                 "rotor_frequency": 1.0e12,
-                "transition_query": [{"ch1": {"P": [-1], "D": [0]}}],
+                "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}],
             },
         ]
         return {"spectral_dimensions": [{"events": events_0}, {"events": events_1}]}

--- a/src/mrsimulator/method/lib/stvas.py
+++ b/src/mrsimulator/method/lib/stvas.py
@@ -51,14 +51,14 @@ class ST_VAS(BaseNamedMethod2D):
         # setting transition symmetry elements for spectral dimension 0
         events_0 = [
             {
-                "transition_query": [
+                "transition_queries": [
                     {"ch1": {"P": [-1], "D": [d]}},
                     {"ch1": {"P": [-1], "D": [-d]}},
                 ]
             }
         ]
         # setting transition symmetry elements for spectral dimension 1
-        events_1 = [{"transition_query": [{"ch1": {"P": [-1], "D": [0]}}]}]
+        events_1 = [{"transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]}]
 
         # method affine matrix shear factor
         k = shear_factor_ST_MAS[int(2 * st)][spin]

--- a/src/mrsimulator/method/plot.py
+++ b/src/mrsimulator/method/plot.py
@@ -533,7 +533,7 @@ def _add_angle_and_phase(df):
         df["phase"] = [None] * len(df["type"])
         return
 
-    # Keep queries where at least one RotationalQuery is not None
+    # Keep queries where at least one RotationQuery is not None
     # cannot use `is not None` in numpy arguments below
     queries = queries[:, np.any(queries != None, axis=0)]  # noqa:E711
     # TODO: Need to ensure at least one channel, maybe check if queries is empty

--- a/src/mrsimulator/method/query.py
+++ b/src/mrsimulator/method/query.py
@@ -41,7 +41,7 @@ class SymmetryQuery(Parseable):
         >>> method = Method(channels=['1H'], spectral_dimensions=[{"events": [
         ...     {"fraction": 1}
         ... ]}])
-        >>> method.spectral_dimensions[0].events[0].transition_query[0].ch1.P = [-1]
+        >>> method.spectral_dimensions[0].events[0].transition_queries[0].ch1.P = [-1]
 
     D:
         A list of d symmetry functions per site. Here d = :math:`m_f^2 - m_i^2` is the
@@ -51,7 +51,7 @@ class SymmetryQuery(Parseable):
         Example
         -------
 
-        >>> method.spectral_dimensions[0].events[0].transition_query[0].ch1.D = [0]
+        >>> method.spectral_dimensions[0].events[0].transition_queries[0].ch1.D = [0]
 
     """
 

--- a/src/mrsimulator/method/query.py
+++ b/src/mrsimulator/method/query.py
@@ -254,8 +254,8 @@ class TransitionQuery(Parseable):
         return all_combinations
 
 
-class RotationalQuery(Parseable):
-    """Base RotationalQuery class.
+class RotationQuery(Parseable):
+    """Base RotationQuery class.
 
     Attributes
     ----------
@@ -285,13 +285,13 @@ class MixingQuery(Parseable):
     ----------
 
     ch1:
-        An optional RotationalQuery object for channel at index 0 of method's channels."
+        An optional RotationQuery object for channel at index 0 of method's channels."
 
     ch2:
-        An optional RotationalQuery object for channel at index 1 of method's channels."
+        An optional RotationQuery object for channel at index 1 of method's channels."
 
     ch3:
-        An optional RotationalQuery object for channel at index 2 of method's channels."
+        An optional RotationQuery object for channel at index 2 of method's channels."
 
     Example
     -------
@@ -300,9 +300,9 @@ class MixingQuery(Parseable):
 
     """
 
-    ch1: Optional[RotationalQuery] = None
-    ch2: Optional[RotationalQuery] = None
-    ch3: Optional[RotationalQuery] = None
+    ch1: Optional[RotationQuery] = None
+    ch2: Optional[RotationQuery] = None
+    ch3: Optional[RotationQuery] = None
 
     class Config:
         validate_assignment = True
@@ -323,13 +323,13 @@ class MixingQuery(Parseable):
         """
         py_dict_copy = deepcopy(py_dict)
         obj = {
-            k: RotationalQuery.parse_dict_with_units(v) for k, v in py_dict_copy.items()
+            k: RotationQuery.parse_dict_with_units(v) for k, v in py_dict_copy.items()
         }
         py_dict_copy.update(obj)
         return super().parse_dict_with_units(py_dict_copy)
 
     @property
-    def channels(self) -> List[RotationalQuery]:
+    def channels(self) -> List[RotationQuery]:
         """Returns an ordered list of all channels"""
         return [self.ch1, self.ch2, self.ch3]
 

--- a/src/mrsimulator/method/spectral_dimension.py
+++ b/src/mrsimulator/method/spectral_dimension.py
@@ -214,8 +214,8 @@ class SpectralDimension(Parseable):
     #     df = pd.DataFrame(index=rows)
     #     for i in range(len(self.events)):
     #         _lst = [getattr(self.events[i], att) for att in attributes]
-    #         _lst.append(self.events[i].transition_query.get_p())
-    #         _lst.append(self.events[i].transition_query.get_d())
+    #         _lst.append(self.events[i].transition_queries.get_p())
+    #         _lst.append(self.events[i].transition_queries.get_d())
     #         df[i] = _lst
     #     return df
 
@@ -236,14 +236,14 @@ class SpectralDimension(Parseable):
             >>> sp = SpectralDimension(
             ...     events = [{
             ...         "fraction": 0.5,
-            ...         "transition_query": [
+            ...         "transition_queries": [
             ...             {"ch1": {"P": [1, 1]}, "ch2": {"P": [1], "D": [2]}},
             ...             {"ch1": {"P": [-1, -1]}},
             ...         ]
             ...     },
             ...     {
             ...         "fraction": 0.5,
-            ...         "transition_query": [
+            ...         "transition_queries": [
             ...             {"ch1": {"P": [-1]}},
             ...         ]
             ...     }]
@@ -253,7 +253,7 @@ class SpectralDimension(Parseable):
              {'ch1': [[-1, -1], [-1]], 'ch2': [None, None], 'ch3': [None, None]}]
         """
         ha, ga = hasattr, getattr
-        tq, de = "transition_query", np.asarray([0])
+        tq, de = "transition_queries", np.asarray([0])
 
         indexes = [np.arange(len(ga(e, tq))) if ha(e, tq) else de for e in self.events]
         products = cartesian_product(*indexes)
@@ -261,8 +261,8 @@ class SpectralDimension(Parseable):
         return [
             {
                 ch: [
-                    ga(ga(e.transition_query[i], ch), symmetry_element)
-                    if ha(e, tq) and ga(e.transition_query[i], ch) is not None
+                    ga(ga(e.transition_queries[i], ch), symmetry_element)
+                    if ha(e, tq) and ga(e.transition_queries[i], ch) is not None
                     else None
                     for e, i in zip(self.events, item)
                 ]

--- a/src/mrsimulator/method/tests/lib_tests/test_MQVAS.py
+++ b/src/mrsimulator/method/tests/lib_tests/test_MQVAS.py
@@ -23,12 +23,12 @@ def sample_test_output(n):
             {
                 "count": 1024,
                 "spectral_width": "25000.0 Hz",
-                "events": [{"transition_query": [{"ch1": {"P": [n], "D": [0]}}]}],
+                "events": [{"transition_queries": [{"ch1": {"P": [n], "D": [0]}}]}],
             },
             {
                 "count": 1024,
                 "spectral_width": "25000.0 Hz",
-                "events": [{"transition_query": [{"ch1": {"P": [-1], "D": [0]}}]}],
+                "events": [{"transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]}],
             },
         ],
     }
@@ -65,10 +65,10 @@ def test_3Q_VAS_general():
     mth = ThreeQ_VAS(channels=["87Rb"], spectral_dimensions=[{}, {}])
     assert mth.name == "ThreeQ_VAS"
     assert mth.description == "Simulate a 3Q variable-angle spinning spectrum."
-    assert mth.spectral_dimensions[0].events[0].transition_query == [
+    assert mth.spectral_dimensions[0].events[0].transition_queries == [
         TransitionQuery(ch1={"P": [-3], "D": [0]})
     ]
-    assert mth.spectral_dimensions[1].events[0].transition_query == [
+    assert mth.spectral_dimensions[1].events[0].transition_queries == [
         TransitionQuery(ch1={"P": [-1], "D": [0]})
     ]
     assert ThreeQ_VAS.parse_dict_with_units(mth.json()) == mth
@@ -93,10 +93,10 @@ def test_5Q_VAS_general():
 
     assert mth.name == "FiveQ_VAS"
     assert mth.description == "Simulate a 5Q variable-angle spinning spectrum."
-    assert mth.spectral_dimensions[0].events[0].transition_query == [
+    assert mth.spectral_dimensions[0].events[0].transition_queries == [
         TransitionQuery(ch1={"P": [-5], "D": [0]})
     ]
-    assert mth.spectral_dimensions[1].events[0].transition_query == [
+    assert mth.spectral_dimensions[1].events[0].transition_queries == [
         TransitionQuery(ch1={"P": [-1], "D": [0]})
     ]
     assert FiveQ_VAS.parse_dict_with_units(mth.json()) == mth
@@ -122,10 +122,10 @@ def test_7Q_VAS_general():
 
     assert mth.name == "SevenQ_VAS"
     assert mth.description == "Simulate a 7Q variable-angle spinning spectrum."
-    assert mth.spectral_dimensions[0].events[0].transition_query == [
+    assert mth.spectral_dimensions[0].events[0].transition_queries == [
         TransitionQuery(ch1={"P": [-7], "D": [0]})
     ]
-    assert mth.spectral_dimensions[1].events[0].transition_query == [
+    assert mth.spectral_dimensions[1].events[0].transition_queries == [
         TransitionQuery(ch1={"P": [-1], "D": [0]})
     ]
     assert SevenQ_VAS.parse_dict_with_units(mth.json()) == mth

--- a/src/mrsimulator/method/tests/lib_tests/test_correlation.py
+++ b/src/mrsimulator/method/tests/lib_tests/test_correlation.py
@@ -27,16 +27,16 @@
 #             method(spectral_dimensions=[{}])
 #
 #
-# def test_correlation_setting_transition_query():
+# def test_correlation_setting_transition_queries():
 #     def error(name):
-#         return f"`transition_query` value cannot be modified for {name} method."
+#         return f"`transition_queries` value cannot be modified for {name} method."
 #
 #     for name, method in zip(names, methods):
 #         e = error(name)
 #         with pytest.raises(ValueError, match=f".*{e}.*"):
 #             method(
 #                 spectral_dimensions=[
-#                     {"events": [{"transition_query": {"P": [-1]}}]},
+#                     {"events": [{"transition_queries": {"P": [-1]}}]},
 #                     {},
 #                 ],
 #             )
@@ -64,10 +64,10 @@
 #
 #     des = "Simulate an infinite spinning COrrelation SpectroscopY spectrum."
 #     assert mth.description == des
-#     assert mth.spectral_dimensions[0].events[0].transition_query == TransitionQuery(
+#     assert mth.spectral_dimensions[0].events[0].transition_queries == TransitionQuery(
 #         P={"channel-1": [[-1]]}
 #     )
-#     assert mth.spectral_dimensions[1].events[0].transition_query == TransitionQuery(
+#     assert mth.spectral_dimensions[1].events[0].transition_queries == TransitionQuery(
 #         P={"channel-1": [[-1]]}
 #     )
 #     assert Cosy.parse_dict_with_units(mth.json()) == mth
@@ -120,10 +120,10 @@
 #         "Transfer Experiment spectrum."
 #     )
 #     assert mth.description == des
-#     assert mth.spectral_dimensions[0].events[0].transition_query == TransitionQuery(
+#     assert mth.spectral_dimensions[0].events[0].transition_queries == TransitionQuery(
 #         P={"channel-1": [[-1, -1]]}
 #     )
-#     assert mth.spectral_dimensions[1].events[0].transition_query == TransitionQuery(
+#     assert mth.spectral_dimensions[1].events[0].transition_queries == TransitionQuery(
 #         P={"channel-1": [[-1]]}
 #     )
 #     assert Inadequate.parse_dict_with_units(mth.json()) == mth

--- a/src/mrsimulator/method/tests/lib_tests/test_data.json
+++ b/src/mrsimulator/method/tests/lib_tests/test_data.json
@@ -8,7 +8,7 @@
 				"count": 1024,
 				"spectral_width": "50000.0 Hz",
 				"events": [{
-					"transition_query": [{
+					"transition_queries": [{
 						"ch1": {
 							"P": [-1]
 						}
@@ -19,7 +19,7 @@
 				"count": 1024,
 				"spectral_width": "50000.0 Hz",
 				"events": [{
-					"transition_query": [{
+					"transition_queries": [{
 						"ch1": {
 							"P": [-1]
 						}
@@ -38,7 +38,7 @@
 				"count": 512,
 				"spectral_width": "50000.0 Hz",
 				"events": [{
-					"transition_query": [{
+					"transition_queries": [{
 						"ch1": {
 							"P": [-1],
 							"D": [0]
@@ -51,7 +51,7 @@
 				"spectral_width": "50000.0 Hz",
 				"events": [{
 					"rotor_angle": "0.9553059660790962 rad",
-					"transition_query": [{
+					"transition_queries": [{
 						"ch1": {
 							"P": [-1],
 							"D": [0]
@@ -72,7 +72,7 @@
 				"spectral_width": "5000000.0 Hz",
 				"events": [{
 					"rotor_angle": "0.0 rad",
-					"transition_query": [{
+					"transition_queries": [{
 							"ch1": {
 								"P": [-1],
 								"D": [2]
@@ -92,7 +92,7 @@
 				"spectral_width": "50000.0 Hz",
 				"events": [{
 					"rotor_angle": "0.9553059660790962 rad",
-					"transition_query": [{
+					"transition_queries": [{
 						"ch1": {
 							"P": [-1],
 							"D": [0]
@@ -116,7 +116,7 @@
 				"events": [{
 						"fraction": 0.5,
 						"rotor_angle": "1.2238238377777777 rad",
-						"transition_query": [{
+						"transition_queries": [{
 							"ch1": {
 								"P": [-1],
 								"D": [0]
@@ -126,7 +126,7 @@
 						{
 						"fraction": 0.5,
 						"rotor_angle": "0.5256927266666667 rad",
-						"transition_query": [{
+						"transition_queries": [{
 							"ch1": {
 								"P": [-1],
 								"D": [0]
@@ -141,7 +141,7 @@
 				"reference_offset": "-7000.0 Hz",
 				"label": "MAS dimension",
 				"events": [{
-					"transition_query": [{
+					"transition_queries": [{
 						"ch1": {
 							"P": [-1],
 							"D": [0]

--- a/src/mrsimulator/method/tests/lib_tests/test_method_updates.py
+++ b/src/mrsimulator/method/tests/lib_tests/test_method_updates.py
@@ -54,7 +54,7 @@ def assert_parsing(method, fn1):
     event_error = "Event objects are immutable for"
     serialize = fn1.json()
     ent = serialize["spectral_dimensions"][0]["events"]
-    ent[0]["transition_query"][0]["ch1"]["P"] = [-100]
+    ent[0]["transition_queries"][0]["ch1"]["P"] = [-100]
 
     if method not in [Method]:
         with pytest.raises(ImmutableEventError, match=f".*{event_error}.*"):
@@ -65,7 +65,9 @@ def assert_parsing(method, fn1):
 
         with pytest.raises(ImmutableEventError, match=f".*{event_error}.*"):
             ent[0]["fraction"] = 0.5
-            ent.append({"fraction": 0.5, "transition_query": [{"ch1": {"P": [-100]}}]})
+            ent.append(
+                {"fraction": 0.5, "transition_queries": [{"ch1": {"P": [-100]}}]}
+            )
             method.parse_dict_with_units(serialize)
 
 

--- a/src/mrsimulator/method/tests/lib_tests/test_methods.py
+++ b/src/mrsimulator/method/tests/lib_tests/test_methods.py
@@ -20,7 +20,7 @@ MAS_DIM = {
     "events": [
         {
             "rotor_angle": 54.735 * np.pi / 180,
-            "transition_query": [{"ch1": {"P": [-1], "D": [0]}}],
+            "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}],
         },
     ],
 }
@@ -34,7 +34,7 @@ sample_method_dict = dict(
     ],
 )
 
-sq_tq = {"transition_query": [{"ch1": {"P": [-1]}}]}
+sq_tq = {"transition_queries": [{"ch1": {"P": [-1]}}]}
 sample_test_output = {
     "count": 1024,
     "events": [
@@ -94,7 +94,7 @@ def test_04():
                 "count": 512,
                 "spectral_width": 5e4,  # in Hz
                 "events": [
-                    {"transition_query": [{"ch1": {"P": [-1], "D": [0]}}]},
+                    {"transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]},
                 ],
             },
             MAS_DIM.copy(),
@@ -112,7 +112,7 @@ def test_BlochDecaySpectrum():
     dimension_dictionary_ = {
         "count": 1024,
         "spectral_width": "25000.0 Hz",
-        "events": [{"transition_query": [{"ch1": {"P": [-1]}}]}],
+        "events": [{"transition_queries": [{"ch1": {"P": [-1]}}]}],
     }
 
     should_be = {
@@ -142,7 +142,7 @@ def test_BlochDecaySpectrum():
     dimension_dictionary_ = {
         "count": 1024,
         "spectral_width": "25000.0 Hz",
-        "events": [{"transition_query": [{"ch1": {"P": [-1]}}]}],
+        "events": [{"transition_queries": [{"ch1": {"P": [-1]}}]}],
     }
 
     should_be = {
@@ -169,7 +169,7 @@ def test_05():
         events=[
             {
                 "rotor_angle": 0 * np.pi / 180,
-                "transition_query": [
+                "transition_queries": [
                     {"ch1": {"P": [-1], "D": [2]}},
                     {"ch1": {"P": [-1], "D": [-2]}},
                 ],
@@ -227,12 +227,12 @@ def test_methods():
                     {
                         "fraction": 0.5,
                         "rotor_angle": 70.12 * 3.14159 / 180,  # in rads
-                        "transition_query": [{"ch1": {"P": [-1], "D": [0]}}],
+                        "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}],
                     },
                     {
                         "fraction": 0.5,
                         "rotor_angle": 30.12 * 3.14159 / 180,  # in rads
-                        "transition_query": [{"ch1": {"P": [-1], "D": [0]}}],
+                        "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}],
                     },
                 ],
             },
@@ -242,7 +242,7 @@ def test_methods():
                 "spectral_width": 3e4,  # in Hz
                 "reference_offset": -7e3,  # in Hz
                 "label": "MAS dimension",
-                "events": [{"transition_query": [{"ch1": {"P": [-1], "D": [0]}}]}],
+                "events": [{"transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]}],
             },
         ],
     )

--- a/src/mrsimulator/method/tests/lib_tests/test_ssb2d.py
+++ b/src/mrsimulator/method/tests/lib_tests/test_ssb2d.py
@@ -39,8 +39,8 @@ def test_SSB_general():
 
     # test transition query
     tq = TransitionQuery(ch1={"P": [-1], "D": [0]})
-    assert mth.spectral_dimensions[0].events[0].transition_query[0] == tq
-    assert mth.spectral_dimensions[1].events[0].transition_query[0] == tq
+    assert mth.spectral_dimensions[0].events[0].transition_queries[0] == tq
+    assert mth.spectral_dimensions[1].events[0].transition_queries[0] == tq
 
     # test rotor_frequency
     assert mth.spectral_dimensions[0].events[0].rotor_frequency == 1200
@@ -65,14 +65,14 @@ def test_SSB_general():
             {
                 "count": 1024,
                 "spectral_width": "50000.0 Hz",
-                "events": [{"transition_query": [{"ch1": {"P": [-1], "D": [0]}}]}],
+                "events": [{"transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]}],
             },
             {
                 "count": 1024,
                 "events": [
                     {
                         "rotor_frequency": "1000000000000.0 Hz",
-                        "transition_query": [{"ch1": {"P": [-1], "D": [0]}}],
+                        "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}],
                     }
                 ],
                 "spectral_width": "50000.0 Hz",

--- a/src/mrsimulator/method/tests/lib_tests/test_stvas.py
+++ b/src/mrsimulator/method/tests/lib_tests/test_stvas.py
@@ -22,7 +22,7 @@ def sample_test_output(n):
                 "spectral_width": "50000.0 Hz",
                 "events": [
                     {
-                        "transition_query": [
+                        "transition_queries": [
                             {"ch1": {"P": [-1], "D": [i]}} for i in [n, -n]
                         ]
                     }
@@ -31,7 +31,7 @@ def sample_test_output(n):
             {
                 "count": 1024,
                 "spectral_width": "50000.0 Hz",
-                "events": [{"transition_query": [{"ch1": {"P": [-1], "D": [0]}}]}],
+                "events": [{"transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]}],
             },
         ],
     }
@@ -80,11 +80,11 @@ def test_ST1_VAS_general():
         "spinning spectrum."
     )
     assert mth.description == des
-    assert mth.spectral_dimensions[0].events[0].transition_query == [
+    assert mth.spectral_dimensions[0].events[0].transition_queries == [
         TransitionQuery(ch1={"P": [-1], "D": [2]}),
         TransitionQuery(ch1={"P": [-1], "D": [-2]}),
     ]
-    assert mth.spectral_dimensions[1].events[0].transition_query == [
+    assert mth.spectral_dimensions[1].events[0].transition_queries == [
         TransitionQuery(ch1={"P": [-1], "D": [0]})
     ]
     assert ST1_VAS.parse_dict_with_units(mth.json()) == mth
@@ -107,7 +107,7 @@ def test_ST1_VAS_general():
                 "spectral_width": "30000.0 Hz",
                 "events": [
                     {
-                        "transition_query": [
+                        "transition_queries": [
                             {"ch1": {"P": [-1], "D": [i]}} for i in [2, -2]
                         ]
                     }
@@ -116,7 +116,7 @@ def test_ST1_VAS_general():
             {
                 "count": 1024,
                 "spectral_width": "20000.0 Hz",
-                "events": [{"transition_query": [{"ch1": {"P": [-1], "D": [0]}}]}],
+                "events": [{"transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]}],
             },
         ],
     }
@@ -139,11 +139,11 @@ def test_ST2_VAS_general():
         "spinning spectrum."
     )
     assert mth.description == des
-    assert mth.spectral_dimensions[0].events[0].transition_query == [
+    assert mth.spectral_dimensions[0].events[0].transition_queries == [
         TransitionQuery(ch1={"P": [-1], "D": [4]}),
         TransitionQuery(ch1={"P": [-1], "D": [-4]}),
     ]
-    assert mth.spectral_dimensions[1].events[0].transition_query == [
+    assert mth.spectral_dimensions[1].events[0].transition_queries == [
         TransitionQuery(ch1={"P": [-1], "D": [0]})
     ]
     assert ST2_VAS.parse_dict_with_units(mth.json()) == mth

--- a/src/mrsimulator/method/tests/test_event.py
+++ b/src/mrsimulator/method/tests/test_event.py
@@ -90,7 +90,7 @@ def basic_spectral_and_constant_time_event_tests(the_event, type_="spectral"):
         magnetic_flux_density="11.7 T",
         rotor_frequency="25000.0 Hz",
         rotor_angle=f"{angle} rad",
-        transition_query=[{"ch1": {"P": [0]}}],
+        transition_queries=[{"ch1": {"P": [0]}}],
     )
     should_be = {
         "magnetic_flux_density": 11.7,
@@ -104,7 +104,7 @@ def basic_spectral_and_constant_time_event_tests(the_event, type_="spectral"):
         assert the_event.json(units=False) == {
             "fraction": 1.2,
             **should_be,
-            "transition_query": [{"ch1": {"P": [0]}}],
+            "transition_queries": [{"ch1": {"P": [0]}}],
         }
 
     if type_ == "constant_duration":
@@ -113,7 +113,7 @@ def basic_spectral_and_constant_time_event_tests(the_event, type_="spectral"):
         assert the_event.json(units=False) == {
             "duration": 1.2,
             **should_be,
-            "transition_query": [{"ch1": {"P": [0]}}],
+            "transition_queries": [{"ch1": {"P": [0]}}],
         }
 
 
@@ -179,7 +179,7 @@ def test_Mixing_event():
     the_event = MixingEvent.parse_dict_with_units(mix_event_dict)
     basic_mixing_event_tests(the_event)
 
-    # Queries of MixingEvents, like the transition_query of the SpectralEvent, need
+    # Queries of MixingEvents, like the transition_queries of the SpectralEvent, need
     # to be defined in a channel-wise dict. Check to make sure error is raised when
     # P and D symmetries are supplied at the base level
     with pytest.raises(ValidationError):
@@ -220,7 +220,7 @@ def test_total_and_no_mixing():
 
 
 def check_equal(query, isotopes, channels, res):
-    test = SpectralEvent(transition_query=query).combination(isotopes, channels)
+    test = SpectralEvent(transition_queries=query).combination(isotopes, channels)
     for i, item in enumerate(res):
         for item2 in item[0]:
             assert item2 in test[i]["P"]

--- a/src/mrsimulator/method/tests/test_method.py
+++ b/src/mrsimulator/method/tests/test_method.py
@@ -57,7 +57,7 @@ def basic_method_tests(the_method):
 
     # json()
 
-    evt = [{"fraction": 0.5, "transition_query": [{"ch1": {"P": [0]}}]}] * 2
+    evt = [{"fraction": 0.5, "transition_queries": [{"ch1": {"P": [0]}}]}] * 2
     serialize = {
         "name": "test worked",
         "description": "test worked again",
@@ -150,7 +150,7 @@ def test_method():
     assert the_method.simulation == csdm_dataset
 
     # json()
-    event_dictionary_ = {"fraction": 0.5, "transition_query": [{"ch1": {"P": [0]}}]}
+    event_dictionary_ = {"fraction": 0.5, "transition_queries": [{"ch1": {"P": [0]}}]}
     dimension_dictionary_ = {
         "count": 1024,
         "spectral_width": "100.0 Hz",
@@ -172,7 +172,7 @@ def test_method():
     assert serialize == method_dictionary_
 
     # json(units=False)
-    event_dictionary_ = {"fraction": 0.5, "transition_query": [{"ch1": {"P": [0]}}]}
+    event_dictionary_ = {"fraction": 0.5, "transition_queries": [{"ch1": {"P": [0]}}]}
     dimension_dictionary_ = {
         "count": 1024,
         "spectral_width": 100.0,

--- a/src/mrsimulator/method/tests/test_plot.py
+++ b/src/mrsimulator/method/tests/test_plot.py
@@ -413,7 +413,7 @@ def method2_df():
                     },
                     {
                         "fraction": 1,
-                        "transition_query": [{"ch1": {"P": [1], "D": [0]}}],
+                        "transition_queries": [{"ch1": {"P": [1], "D": [0]}}],
                     },
                     {
                         "query": {
@@ -429,7 +429,7 @@ def method2_df():
                     },
                     {
                         "duration": 1.5,
-                        "transition_query": [{"ch1": {"P": [-1], "D": [2]}}],
+                        "transition_queries": [{"ch1": {"P": [-1], "D": [2]}}],
                     },
                 ],
             },
@@ -484,14 +484,14 @@ def method3_df():
                 "events": [
                     {
                         "fraction": 0.1,
-                        "transition_query": [
+                        "transition_queries": [
                             {"ch1": {"P": [1, 1]}},
                             {"ch1": {"P": [2]}},
                         ],
                     },
                     {
                         "fraction": 0.9,
-                        "transition_query": [
+                        "transition_queries": [
                             {"ch1": {"P": [-1, -1]}},
                             {"ch1": {"P": [-2]}},
                         ],

--- a/src/mrsimulator/method/tests/test_query.py
+++ b/src/mrsimulator/method/tests/test_query.py
@@ -1,7 +1,7 @@
 import numpy as np
 from mrsimulator.method.query import MixingEnum
 from mrsimulator.method.query import MixingQuery
-from mrsimulator.method.query import RotationalQuery
+from mrsimulator.method.query import RotationQuery
 from mrsimulator.method.query import SymmetryQuery
 from mrsimulator.method.query import TransitionQuery
 
@@ -52,21 +52,21 @@ def test_TransitionQuery():
 def test_RFRotation():
     # parse units
     test = {"angle": "90 deg", "phase": "5 deg"}
-    rf_obj = RotationalQuery.parse_dict_with_units(test)
+    rf_obj = RotationQuery.parse_dict_with_units(test)
     assert rf_obj.name is None
     assert rf_obj.description is None
     assert rf_obj.label is None
-    assert rf_obj.angle == np.pi / 2.0, "RotationalQuery angle not equal."
-    assert rf_obj.phase == 5 * np.pi / 180, "RotationalQuery phase not equal."
+    assert rf_obj.angle == np.pi / 2.0, "RotationQuery angle not equal."
+    assert rf_obj.phase == 5 * np.pi / 180, "RotationQuery phase not equal."
     # ensure the default value is rad
     assert rf_obj.property_units["angle"] == "rad"
     assert rf_obj.property_units["phase"] == "rad"
 
     # direct initialization
     test = {"angle": 3.1415, "phase": 1.212}
-    rf_obj = RotationalQuery(**test)
-    assert rf_obj.angle == 3.1415, "RotationalQuery angle not equal."
-    assert rf_obj.phase == 1.212, "RotationalQuery phase not equal."
+    rf_obj = RotationQuery(**test)
+    assert rf_obj.angle == 3.1415, "RotationQuery angle not equal."
+    assert rf_obj.phase == 1.212, "RotationQuery phase not equal."
 
 
 def test_MixingQuery():
@@ -76,8 +76,8 @@ def test_MixingQuery():
         "ch2": {"angle": "0.12 rad", "phase": "176 deg"},
     }
     obj1 = MixingQuery.parse_dict_with_units(test1)
-    rf1 = RotationalQuery(angle=2.12, phase=-176 * np.pi / 180)
-    rf2 = RotationalQuery(angle=0.12, phase=176 * np.pi / 180)
+    rf1 = RotationQuery(angle=2.12, phase=-176 * np.pi / 180)
+    rf2 = RotationQuery(angle=0.12, phase=176 * np.pi / 180)
     assert obj1.name is None
     assert obj1.description is None
     assert obj1.label is None
@@ -93,7 +93,7 @@ def test_MixingQuery():
     assert obj2.description is None
     assert obj2.label is None
     assert obj2.ch1 is None
-    assert obj2.ch2 == RotationalQuery(angle=5.101, phase=1.61)
+    assert obj2.ch2 == RotationQuery(angle=5.101, phase=1.61)
     assert obj2.ch3 is None
 
 

--- a/src/mrsimulator/method/tests/test_spectral_dimension.py
+++ b/src/mrsimulator/method/tests/test_spectral_dimension.py
@@ -89,7 +89,7 @@ def basic_spectral_dimension_tests(the_dimension):
                 "magnetic_flux_density": "9.6 T",
                 "rotor_angle": "0.9553059660790962 rad",
                 "rotor_frequency": "1000.0 Hz",
-                "transition_query": [{"ch1": {"P": [0]}}],
+                "transition_queries": [{"ch1": {"P": [0]}}],
             }
         ],
     )
@@ -107,7 +107,7 @@ def basic_spectral_dimension_tests(the_dimension):
                 "magnetic_flux_density": 9.6,
                 "rotor_angle": 0.9553059660790962,
                 "rotor_frequency": 1000.0,
-                "transition_query": [{"ch1": {"P": [0]}}],
+                "transition_queries": [{"ch1": {"P": [0]}}],
             }
         ],
     )
@@ -177,14 +177,14 @@ def test_spectral_dimension():
                 "magnetic_flux_density": "9.6 T",
                 "rotor_angle": "0.9553059660790962 rad",
                 "rotor_frequency": "1000.0 Hz",
-                "transition_query": [{"ch1": {"P": [0]}}],
+                "transition_queries": [{"ch1": {"P": [0]}}],
             },
             {
                 "fraction": 0.5,
                 "magnetic_flux_density": "9.6 T",
                 "rotor_angle": "0.9553059660790962 rad",
                 "rotor_frequency": "1000.0 Hz",
-                "transition_query": [{"ch1": {"P": [0]}}],
+                "transition_queries": [{"ch1": {"P": [0]}}],
             },
         ],
     )
@@ -202,7 +202,7 @@ def test_spectral_dimension():
                 "magnetic_flux_density": 9.6,
                 "rotor_angle": 0.9553059660790962,
                 "rotor_frequency": 1000.0,
-                "transition_query": [{"ch1": {"P": [0]}}],
+                "transition_queries": [{"ch1": {"P": [0]}}],
             },
             {
                 "fraction": 0.5,
@@ -210,7 +210,7 @@ def test_spectral_dimension():
                 "magnetic_flux_density": 9.6,
                 "rotor_angle": 0.9553059660790962,
                 "rotor_frequency": 1000.0,
-                "transition_query": [{"ch1": {"P": [0]}}],
+                "transition_queries": [{"ch1": {"P": [0]}}],
             },
         ],
     )

--- a/src/mrsimulator/method/tests/test_summary.py
+++ b/src/mrsimulator/method/tests/test_summary.py
@@ -165,7 +165,7 @@ def test_summary():
                     "magnetic_flux_density": 1,
                     "rotor_frequency": 0,  # in kHz
                     "rotor_angle": 0.1,
-                    "transition_query": [{"ch1": {"P": [0], "D": [0]}}],
+                    "transition_queries": [{"ch1": {"P": [0], "D": [0]}}],
                 },
                 {
                     "label": "Spec0",
@@ -173,7 +173,7 @@ def test_summary():
                     "magnetic_flux_density": 2,
                     "rotor_frequency": 20000,
                     "rotor_angle": 0.2,
-                    "transition_query": [{"ch1": {"P": [1], "D": [-2]}}],
+                    "transition_queries": [{"ch1": {"P": [1], "D": [-2]}}],
                 },
             ]
         },
@@ -189,7 +189,7 @@ def test_summary():
                     "magnetic_flux_density": 3,
                     "rotor_frequency": 0,
                     "rotor_angle": 0.3,
-                    "transition_query": [{"ch1": {"P": [3], "D": [-4]}}],
+                    "transition_queries": [{"ch1": {"P": [3], "D": [-4]}}],
                 },
                 {
                     "label": "Spec1",
@@ -197,7 +197,7 @@ def test_summary():
                     "magnetic_flux_density": 4,
                     "rotor_frequency": 0,
                     "rotor_angle": 0.4,
-                    "transition_query": [{"ch1": {"P": [4], "D": [-6]}}],
+                    "transition_queries": [{"ch1": {"P": [4], "D": [-6]}}],
                 },
             ]
         },
@@ -215,14 +215,14 @@ def test_summary():
                     "duration": 1,
                     "rotor_frequency": 0,
                     "rotor_angle": 0.5,
-                    "transition_query": [{"ch1": {"P": [0], "D": [0]}}],
+                    "transition_queries": [{"ch1": {"P": [0], "D": [0]}}],
                 },
                 {
                     "label": "Spec0",
                     "fraction": 1,
                     "rotor_frequency": 20000,
                     "rotor_angle": 0.5,
-                    "transition_query": [{"ch1": {"P": [1], "D": [0]}}],
+                    "transition_queries": [{"ch1": {"P": [1], "D": [0]}}],
                 },
             ]
         },
@@ -237,14 +237,14 @@ def test_summary():
                     "duration": 2,
                     "rotor_frequency": 0,
                     "rotor_angle": 0.5,
-                    "transition_query": [{"ch1": {"P": [3], "D": [0]}}],
+                    "transition_queries": [{"ch1": {"P": [3], "D": [0]}}],
                 },
                 {
                     "label": "Spec1",
                     "fraction": 1,
                     "rotor_frequency": 0,
                     "rotor_angle": 0.5,
-                    "transition_query": [{"ch1": {"P": [4], "D": [0]}}],
+                    "transition_queries": [{"ch1": {"P": [4], "D": [0]}}],
                 },
             ]
         },

--- a/src/mrsimulator/method/tests/test_transitions.py
+++ b/src/mrsimulator/method/tests/test_transitions.py
@@ -12,12 +12,12 @@ __email__ = "srivastava.89@osu.edu"
 
 method1 = Method(
     channels=["13C"],
-    spectral_dimensions=[{"events": [{"transition_query": [{"ch1": {"P": [-1]}}]}]}],
+    spectral_dimensions=[{"events": [{"transition_queries": [{"ch1": {"P": [-1]}}]}]}],
 )
 
 method2 = Method(
     channels=["13C"],
-    spectral_dimensions=[{"events": [{"transition_query": [{"ch1": {"P": [-2]}}]}]}],
+    spectral_dimensions=[{"events": [{"transition_queries": [{"ch1": {"P": [-2]}}]}]}],
 )
 
 
@@ -96,9 +96,9 @@ def test_hahn():
         spectral_dimensions=[
             {
                 "events": [
-                    {"fraction": 0.5, "transition_query": [{"ch1": {"P": [1]}}]},
+                    {"fraction": 0.5, "transition_queries": [{"ch1": {"P": [1]}}]},
                     {"query": {"ch1": {"angle": np.pi, "phase": 0}}},
-                    {"fraction": 0.5, "transition_query": [{"ch1": {"P": [-1]}}]},
+                    {"fraction": 0.5, "transition_queries": [{"ch1": {"P": [-1]}}]},
                 ]
             },
         ],
@@ -124,12 +124,14 @@ def test_cosy():
         spectral_dimensions=[
             {
                 "events": [
-                    {"fraction": 1, "transition_query": [{"ch1": {"P": [-1]}}]},
+                    {"fraction": 1, "transition_queries": [{"ch1": {"P": [-1]}}]},
                     {"query": {"ch1": {"angle": np.pi / 2, "phase": 0}}},
                 ],
             },
             {
-                "events": [{"fraction": 1, "transition_query": [{"ch1": {"P": [-1]}}]}],
+                "events": [
+                    {"fraction": 1, "transition_queries": [{"ch1": {"P": [-1]}}]}
+                ],
             },
         ],
     )
@@ -169,12 +171,12 @@ def test_total_mixing():
         spectral_dimensions=[
             SpectralDimension(
                 events=[
-                    SpectralEvent(transition_query=[{"ch1": {"P": [-1]}}]),
+                    SpectralEvent(transition_queries=[{"ch1": {"P": [-1]}}]),
                     MixingEvent(query=MixingEnum.TotalMixing),
                 ]
             ),
             SpectralDimension(
-                events=[SpectralEvent(transition_query=[{"ch1": {"P": [-1]}}])]
+                events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-1]}}])]
             ),
         ],
     )
@@ -203,12 +205,12 @@ def test_no_mixing():
         spectral_dimensions=[
             SpectralDimension(
                 events=[
-                    SpectralEvent(transition_query=[{"ch1": {"P": [-1]}}]),
+                    SpectralEvent(transition_queries=[{"ch1": {"P": [-1]}}]),
                     MixingEvent(query=MixingEnum.NoMixing),
                 ]
             ),
             SpectralDimension(
-                events=[SpectralEvent(transition_query=[{"ch1": {"P": [-1]}}])]
+                events=[SpectralEvent(transition_queries=[{"ch1": {"P": [-1]}}])]
             ),
         ],
     )

--- a/src/mrsimulator/simulator/tests/test_simulator.py
+++ b/src/mrsimulator/simulator/tests/test_simulator.py
@@ -132,7 +132,7 @@ def test_simulator_1():
                 "spectral_dimensions": [
                     {
                         "count": 1024,
-                        "events": [{"transition_query": [{"ch1": {"P": [-1]}}]}],
+                        "events": [{"transition_queries": [{"ch1": {"P": [-1]}}]}],
                         "spectral_width": 25000.0,
                     }
                 ],

--- a/src/mrsimulator/tests/test_convert_funcs.py
+++ b/src/mrsimulator/tests/test_convert_funcs.py
@@ -35,7 +35,7 @@ def test_parse_old_structure():
     assert test_app == app
 
     # Test old root level and convert transition queries
-    old_queries = test_data["old_root_level_and_transition_query"]
+    old_queries = test_data["old_root_level_and_transition_queries"]
     with pytest.warns(Warning, match=e):
         test_sim, test_sp, test_app = parse(old_queries)
 
@@ -51,13 +51,13 @@ def test_parse_old_structure():
 
 
 def test_update_old_dict_struct():
-    old_struct = test_data["old_root_level_and_transition_query"]
+    old_struct = test_data["old_root_level_and_transition_queries"]
     should_be = test_data["serialization_should_be"]
     assert update_old_dict_struct(old_struct) == Mrsimulator.parse(should_be).json()
 
 
 def test_update_old_file_struct():
-    old_struct = test_data["old_root_level_and_transition_query"]
+    old_struct = test_data["old_root_level_and_transition_queries"]
 
     # Save old dictionary to mrsim file
     with open("old_struct.mrsim", "w", encoding="utf8") as outfile:

--- a/src/mrsimulator/tests/test_data.json
+++ b/src/mrsimulator/tests/test_data.json
@@ -38,12 +38,12 @@
                             {
                                 "fraction": 0.5,
                                 "rotor_angle": "0.6524035233333334 rad",
-                                "transition_query": [{"ch1": {"P": [-1], "D": [0]}}]
+                                "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]
                             },
                             {
                                 "fraction": 0.5,
                                 "rotor_angle": "1.3821250672222223 rad",
-                                "transition_query": [{"ch1": {"P": [-1], "D": [0]}}]
+                                "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]
                             }
                         ]
                     },
@@ -53,7 +53,7 @@
                         "events": [
                             {
                                 "rotor_angle": "0.9553051591666667 rad",
-                                "transition_query": [{"ch1": {"P": [-1], "D": [0]}}]
+                                "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]
                             }
                         ]
                     }
@@ -78,7 +78,7 @@
         ],
         "some_bad_key": "I should be removed"
     },
-    "old_root_level_and_transition_query": {
+    "old_root_level_and_transition_queries": {
         "name": "Test Conversion Simulator",
         "description": "JSON to test conversion of old structures",
         "label": "Simulator label",
@@ -116,12 +116,12 @@
                             {
                                 "fraction": 0.5,
                                 "rotor_angle": "0.6524035233333334 rad",
-                                "transition_query": {"P": [-1], "D": [0]}
+                                "transition_queries": {"P": [-1], "D": [0]}
                             },
                             {
                                 "fraction": 0.5,
                                 "rotor_angle": "1.3821250672222223 rad",
-                                "transition_query": {"P": [-1], "D": [0]}
+                                "transition_queries": {"P": [-1], "D": [0]}
                             }
                         ]
                     },
@@ -131,7 +131,7 @@
                         "events": [
                             {
                                 "rotor_angle": "0.9553051591666667 rad",
-                                "transition_query": {"P": [-1], "D": [0]}
+                                "transition_queries": {"P": [-1], "D": [0]}
                             }
                         ]
                     }
@@ -195,12 +195,12 @@
                                 {
                                     "fraction": 0.5,
                                     "rotor_angle": "0.6524035233333334 rad",
-                                    "transition_query": [{"ch1": {"P": [-1], "D": [0]}}]
+                                    "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]
                                 },
                                 {
                                     "fraction": 0.5,
                                     "rotor_angle": "1.3821250672222223 rad",
-                                    "transition_query": [{"ch1": {"P": [-1], "D": [0]}}]
+                                    "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]
                                 }
                             ]
                         },
@@ -210,7 +210,7 @@
                             "events": [
                                 {
                                     "rotor_angle": "0.9553051591666667 rad",
-                                    "transition_query": [{"ch1": {"P": [-1], "D": [0]}}]
+                                    "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]
                                 }
                             ]
                         }

--- a/src/mrsimulator/utils/parseable.py
+++ b/src/mrsimulator/utils/parseable.py
@@ -33,7 +33,7 @@ INCLUDE_LIST = [
     "number_of_sidebands",
     "name",
     "description",
-    "transition_query",
+    "transition_queries",
     "ch1",
     "P",
     "channels",

--- a/src/mrsimulator/utils/tests/test_query_conversion.py
+++ b/src/mrsimulator/utils/tests/test_query_conversion.py
@@ -1,30 +1,30 @@
 from copy import deepcopy
 
 import pytest
-from mrsimulator.utils.utils import convert_transition_query
+from mrsimulator.utils.utils import convert_transition_queries
 
 
 def template(tq):
-    return {"spectral_dimensions": [{"events": [{"transition_query": tq}]}]}
+    return {"spectral_dimensions": [{"events": [{"transition_queries": tq}]}]}
 
 
-def test_convert_transition_query():
+def test_convert_transition_queries():
     tq = {"P": -1, "D": -2}
     mth = template(tq)
     res = deepcopy(mth)
-    convert_transition_query(res)
+    convert_transition_queries(res)
     assert res == template([{"ch1": {"P": [-1], "D": [-2]}}])
 
     tq = {"P": -1}
     mth = template(tq)
     res = deepcopy(mth)
-    convert_transition_query(res)
+    convert_transition_queries(res)
     assert res == template([{"ch1": {"P": [-1]}}])
 
     tq = {"D": 2}
     mth = template(tq)
     res = deepcopy(mth)
-    convert_transition_query(res)
+    convert_transition_queries(res)
     assert res == template([{"ch1": {"D": [2]}}])
 
     tq = {"P": -1, "D": [-2, -1]}
@@ -32,23 +32,23 @@ def test_convert_transition_query():
     res = deepcopy(mth)
     error = "Ambiguous definition for transition queries"
     with pytest.raises(Exception, match=f".*{error}.*"):
-        convert_transition_query(res)
+        convert_transition_queries(res)
 
     # assert res == template([{"P": [-1], "D": [-2]}, {"P": [-1], "D": [-1]}])
     # tq = {"D": [-2, -1]}
     # mth = template(tq)
     # res = deepcopy(mth)
-    # convert_transition_query(res)
+    # convert_transition_queries(res)
     # assert res == template([{"D": [-2]}, {"D": [-1]}])
     # tq = {"P": [-2], "D": [-4, 4]}
     # mth = template(tq)
     # res = deepcopy(mth)
-    # convert_transition_query(res)
+    # convert_transition_queries(res)
     # assert res == template([{"P": [-2], "D": [-4]}, {"P": [-2], "D": [4]}])
     # tq = {"P": [-2, 2], "D": [-4, 4]}
     # mth = template(tq)
     # res = deepcopy(mth)
-    # convert_transition_query(res)
+    # convert_transition_queries(res)
     # assert res == template(
     #     [
     #         {"P": [-2], "D": [-4]},
@@ -60,21 +60,21 @@ def test_convert_transition_query():
     # tq = {"P": [[1, 1]], "D": [-4, 4]}
     # mth = template(tq)
     # res = deepcopy(mth)
-    # convert_transition_query(res)
+    # convert_transition_queries(res)
     # assert res == template([{"P": [1, 1], "D": [-4]}, {"P": [1, 1], "D": [4]}])
 
     tq = {"P": [[1, 1]]}
     mth = template(tq)
     res = deepcopy(mth)
-    convert_transition_query(res)
+    convert_transition_queries(res)
     assert res == template([{"ch1": {"P": [1, 1]}}])
 
     mth = {"spectral_dimensions": [{}]}
     res = deepcopy(mth)
-    convert_transition_query(res)
+    convert_transition_queries(res)
     assert res == mth
 
     mth = {"spectral_dimensions": [{"events": [{}]}]}
     res = deepcopy(mth)
-    convert_transition_query(res)
+    convert_transition_queries(res)
     assert res == mth

--- a/src/mrsimulator/utils/utils.py
+++ b/src/mrsimulator/utils/utils.py
@@ -42,13 +42,13 @@ def _update_old_dict_struct(py_dict):
 
     # Attempt to convert old transition queries
     if "methods" in py_dict["simulator"]:
-        _ = [convert_transition_query(mtd) for mtd in py_dict["simulator"]["methods"]]
+        _ = [convert_transition_queries(mtd) for mtd in py_dict["simulator"]["methods"]]
 
     return py_dict
 
 
-def convert_transition_query(py_dict):
-    """Convert transition_query->P->... to transition_query->ch1->P->... if no channel
+def convert_transition_queries(py_dict):
+    """Convert transition_queries->P->... to transition_queries->ch1->P->... if no channel
     is defined."""
     # check if old structure without channels
     missing_channels = (
@@ -56,36 +56,36 @@ def convert_transition_query(py_dict):
         for dim in py_dict["spectral_dimensions"]
         if "spectral_dimensions" in py_dict and "events" in dim
         for evt in dim["events"]
-        if "transition_query" in evt
-        for tq in evt["transition_query"]
+        if "transition_queries" in evt
+        for tq in evt["transition_queries"]
     )
     if not all(missing_channels):
         return
 
-    map_transition_query_object_to_v_7(py_dict)
+    map_transition_queries_object_to_v_7(py_dict)
     # warnings.warn(VO7_QUERY_WARNING, UserWarning)
     # Add channels to transition queries
     for dim in py_dict["spectral_dimensions"]:
         if "events" in dim:
             for event in dim["events"]:
-                if "transition_query" in event:
-                    transitions = [{"ch1": tq} for tq in event["transition_query"]]
-                    event["transition_query"] = transitions
+                if "transition_queries" in event:
+                    transitions = [{"ch1": tq} for tq in event["transition_queries"]]
+                    event["transition_queries"] = transitions
 
 
-def map_transition_query_object_to_v_7(py_dict):
+def map_transition_queries_object_to_v_7(py_dict):
     """Update the transition query dict object from version 0.6 to version 0.7
 
     1. update transition query dist to a list of dicts.
     """
     # update transition query list
     _ = [
-        evt.update({"transition_query": [evt["transition_query"]]})
+        evt.update({"transition_queries": [evt["transition_queries"]]})
         for dim in py_dict["spectral_dimensions"]
         if "events" in dim
         for evt in dim["events"]
-        if "transition_query" in evt
-        if not isinstance(evt["transition_query"], list)
+        if "transition_queries" in evt
+        if not isinstance(evt["transition_queries"], list)
     ]
 
     _ = [
@@ -93,7 +93,7 @@ def map_transition_query_object_to_v_7(py_dict):
         for dim in py_dict["spectral_dimensions"]
         if "events" in dim
         for evt in dim["events"]
-        if "transition_query" in evt
+        if "transition_queries" in evt
     ]
 
 
@@ -138,10 +138,10 @@ def map_p_and_d_symmetry_to_v_7(py_dict):
             return [{"P": p if isinstance(p, list) else [p]} for p in itemP]
 
     val = []
-    for item in py_dict["transition_query"]:
+    for item in py_dict["transition_queries"]:
         val += expand_p_and_d(item) if "P" in item or "D" in item else [item]
 
-    py_dict.update({"transition_query": val})
+    py_dict.update({"transition_queries": val})
 
 
 # def prepare_method_structure(template, **kwargs):
@@ -185,9 +185,9 @@ def map_p_and_d_symmetry_to_v_7(py_dict):
 #                 parse_events(evt)
 #     return spectral_dimensions
 # def parse_events(evt):
-#     if "transition_query" not in evt.keys():
+#     if "transition_queries" not in evt.keys():
 #         return
-#     t_query = evt["transition_query"]
+#     t_query = evt["transition_queries"]
 #     for item in t_query:
 #         keys = item.keys()
 #         if "ch1" not in keys and "ch2" not in keys and "ch3" not in keys:

--- a/tests/1D_spectrum_tests/test_MQMAS_quad_shear.py
+++ b/tests/1D_spectrum_tests/test_MQMAS_quad_shear.py
@@ -51,12 +51,12 @@ def setup_simulation(site, affine_matrix, class_id=0):
                     {
                         "fraction": 27 / 17,
                         "freq_contrib": ["Quad2_0"],
-                        "transition_query": [{"ch1": {"P": [-1], "D": [0]}}],
+                        "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}],
                     },
                     {
                         "fraction": 1,
                         "freq_contrib": ["Quad2_4"],
-                        "transition_query": [{"ch1": {"P": [-1], "D": [0]}}],
+                        "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}],
                     },
                 ],
             }

--- a/tests/1D_spectrum_tests/test_coupling_freq_contrib.py
+++ b/tests/1D_spectrum_tests/test_coupling_freq_contrib.py
@@ -37,9 +37,9 @@ def hahn_method():
                 count=512,
                 spectral_width=2e4,  # in Hz
                 events=[
-                    SpectralEvent(fraction=0.5, transition_query=positive_sq_tq),
+                    SpectralEvent(fraction=0.5, transition_queries=positive_sq_tq),
                     MixingEvent(query={"ch1": {"angle": np.pi, "phase": 0}}),
-                    SpectralEvent(fraction=0.5, transition_query=negative_sq_tq),
+                    SpectralEvent(fraction=0.5, transition_queries=negative_sq_tq),
                 ],
             )
         ],
@@ -62,7 +62,9 @@ def contrib_method(contrib):
                 count=512,
                 spectral_width=2e4,
                 events=[
-                    SpectralEvent(freq_contrib=contrib, transition_query=negative_sq_tq)
+                    SpectralEvent(
+                        freq_contrib=contrib, transition_queries=negative_sq_tq
+                    )
                 ],
             )
         ],

--- a/tests/2D_spectrum_tests/test_coaster.py
+++ b/tests/2D_spectrum_tests/test_coaster.py
@@ -45,7 +45,7 @@ def coaster_simulation():
                 reference_offset=-8e3,  # in Hz
                 label="$\\omega_1$ (CSA)",
                 events=[
-                    SpectralEvent(transition_query=[{"ch1": {"P": [3], "D": [0]}}]),
+                    SpectralEvent(transition_queries=[{"ch1": {"P": [3], "D": [0]}}]),
                     MixingEvent(query={"ch1": {"angle": np.pi * 109.5 / 180}}),
                 ],
             ),
@@ -55,7 +55,7 @@ def coaster_simulation():
                 reference_offset=-4e3,  # in Hz
                 label="$\\omega_2$ (Q)",
                 events=[
-                    SpectralEvent(transition_query=[{"ch1": {"P": [-1], "D": [0]}}])
+                    SpectralEvent(transition_queries=[{"ch1": {"P": [-1], "D": [0]}}])
                 ],
             ),
         ],
@@ -78,7 +78,7 @@ def csa_1D_projection():
                 events=[
                     SpectralEvent(
                         freq_contrib=["Quad2_0", "Shielding1_0", "Shielding1_2"],
-                        transition_query=[{"ch1": {"P": [3], "D": [0]}}],
+                        transition_queries=[{"ch1": {"P": [3], "D": [0]}}],
                     ),
                 ],
             )
@@ -102,7 +102,7 @@ def quad_1D_projection():
                     SpectralEvent(
                         fraction=1 / 4,
                         freq_contrib=["Quad2_0"],
-                        transition_query=[{"ch1": {"P": [3], "D": [0]}}],
+                        transition_queries=[{"ch1": {"P": [3], "D": [0]}}],
                     ),
                     MixingEvent(
                         query={"ch1": {"angle": np.pi * 109.5 / 180, "phase": 0}}
@@ -110,7 +110,7 @@ def quad_1D_projection():
                     SpectralEvent(
                         fraction=3 / 4,
                         freq_contrib=["Quad2_0", "Quad2_2"],
-                        transition_query=[{"ch1": {"P": [-1], "D": [0]}}],
+                        transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
                     ),
                 ],
             )

--- a/tests/2D_spectrum_tests/test_das.py
+++ b/tests/2D_spectrum_tests/test_das.py
@@ -57,12 +57,12 @@ def test_DAS():
                     {
                         "fraction": 0.5,
                         "rotor_angle": 37.38 * 3.14159 / 180,
-                        "transition_query": [{"ch1": {"P": [-1], "D": [0]}}],
+                        "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}],
                     },
                     {
                         "fraction": 0.5,
                         "rotor_angle": 79.19 * 3.14159 / 180,
-                        "transition_query": [{"ch1": {"P": [-1], "D": [0]}}],
+                        "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}],
                     },
                 ],
             },
@@ -76,7 +76,7 @@ def test_DAS():
                 "events": [
                     {
                         "rotor_angle": 54.735 * 3.14159 / 180,
-                        "transition_query": [{"ch1": {"P": [-1], "D": [0]}}],
+                        "transition_queries": [{"ch1": {"P": [-1], "D": [0]}}],
                     }
                 ],
             },

--- a/tests/2D_spectrum_tests/test_mqmas.py
+++ b/tests/2D_spectrum_tests/test_mqmas.py
@@ -29,12 +29,12 @@ def test_MQMAS():
             {
                 "count": 128,
                 "spectral_width": 20000,
-                "events": [{"transition_query": [{"ch1": {"P": [-3], "D": [0]}}]}],
+                "events": [{"transition_queries": [{"ch1": {"P": [-3], "D": [0]}}]}],
             },
             {
                 "count": 128,
                 "spectral_width": 20000,
-                "events": [{"transition_query": [{"ch1": {"P": [-1], "D": [0]}}]}],
+                "events": [{"transition_queries": [{"ch1": {"P": [-1], "D": [0]}}]}],
             },
         ],
     )

--- a/tests/2D_spectrum_tests/test_ssb.py
+++ b/tests/2D_spectrum_tests/test_ssb.py
@@ -29,7 +29,7 @@ def SSB2D_setup(ist, vr, method_type):
     spin_systems = [SpinSystem(sites=[s]) for s in sites]
 
     B0 = 11.7
-    sq_tq = {"transition_query": [{"ch1": {"P": [-1]}}]}
+    sq_tq = {"transition_queries": [{"ch1": {"P": [-1]}}]}
     if method_type == "PASS":
         method = SSB2D(
             channels=[ist],

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test00/test00.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test00/test00.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "0 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test01/test01.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test01/test01.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "90 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test02/test02.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test02/test02.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "70.12 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test03/test03.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test03/test03.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "65 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test04/test04.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test04/test04.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "54.74 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test05/test05.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test05/test05.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "45 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test06/test06.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test06/test06.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "30.56 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test07/test07.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test07/test07.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "90 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test08/test08.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test08/test08.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "70.12 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test09/test09.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test09/test09.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "65 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test10/test10.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test10/test10.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "54.74 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test11/test11.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test11/test11.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "45 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test12/test12.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test12/test12.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "30.56 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test13/test13.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test13/test13.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "90 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test14/test14.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test14/test14.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "70.12 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test15/test15.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test15/test15.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "65 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test16/test16.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test16/test16.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "54.74 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test17/test17.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test17/test17.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "45 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test18/test18.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/quad/test18/test18.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "4.697 T",
         "rotor_frequency": "12.5 kHz",
         "rotor_angle": "30.56 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/shielding/test00/test00.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/shielding/test00/test00.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "0 kHz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/shielding/test01/test01.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/shielding/test01/test01.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "0 kHz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/shielding/test02/test02.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/shielding/test02/test02.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "0 kHz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/shielding/test03/test03.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/shielding/test03/test03.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "0 kHz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/spectral_integration_tests/python_brute_force_lineshapes/shielding/test04/test04.json
+++ b/tests/spectral_integration_tests/python_brute_force_lineshapes/shielding/test04/test04.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "0 kHz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/csa_quad/test00/test00.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/csa_quad/test00/test00.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.735 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/csa_quad/test01/test01.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/csa_quad/test01/test01.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.735 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/csa_quad/test02/test02.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/csa_quad/test02/test02.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.735 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/csa_quad/test03/test03.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/csa_quad/test03/test03.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.735 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/csa_quad/test04/test04.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/csa_quad/test04/test04.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.735 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/csa_quad/test05/test05.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/csa_quad/test05/test05.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.735 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test00/test00.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test00/test00.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test01/test01.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test01/test01.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test02/test02.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test02/test02.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test03/test03.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test03/test03.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "1 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test04/test04.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test04/test04.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "1 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test05/test05.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test05/test05.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "1 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test06/test06.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/dipolar-coupling/test06/test06.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "1 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test00/test00.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test00/test00.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test01/test01.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test01/test01.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test02/test02.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test02/test02.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test03/test03.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test03/test03.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test04/test04.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test04/test04.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test05/test05.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test05/test05.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test06/test06.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test06/test06.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test07/test07.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test07/test07.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test08/test08.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test08/test08.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test09/test09.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test09/test09.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test10/test10.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test10/test10.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test11/test11.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test11/test11.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test12/test12.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test12/test12.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test13/test13.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test13/test13.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "10 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test14/test14.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test14/test14.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "10 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test15/test15.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test15/test15.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "2 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test16/test16.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test16/test16.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "10 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test17/test17.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test17/test17.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test18/test18.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test18/test18.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "0 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test19/test19.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/j-coupling/test19/test19.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "5 kHz",
         "rotor_angle": "54.7356 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/quad_sidebands/test00/test00.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/quad_sidebands/test00/test00.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "5 kHz",
         "rotor_angle": "54.735 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/quad_sidebands/test01/test01.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/quad_sidebands/test01/test01.json
@@ -8,7 +8,7 @@
         "magnetic_flux_density": "9.4 T",
         "rotor_frequency": "2 kHz",
         "rotor_angle": "54.735 deg",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1],
             "D": [0]

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test00/test00.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test00/test00.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "1 kHz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test01/test01.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test01/test01.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "5 kHz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test02/test02.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test02/test02.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "50 Hz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test03/test03.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test03/test03.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "1 kHz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test04/test04.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test04/test04.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "1 kHz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test05/test05.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test05/test05.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "1 kHz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test06/test06.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test06/test06.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "1 kHz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test07/test07.json
+++ b/tests/spectral_integration_tests/simpson_simulated_lineshapes/shielding_sidebands/test07/test07.json
@@ -7,7 +7,7 @@
       "events": [{
         "magnetic_flux_density": "1 T",
         "rotor_frequency": "1 kHz",
-        "transition_query": [{
+        "transition_queries": [{
           "ch1": {
             "P": [-1]
           }

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -21,7 +21,7 @@ def pre_setup(isotope, shift, reference_offset):
                     "events": [
                         {
                             "magnetic_flux_density": "9.4 T",
-                            "transition_query": [{"ch1": {"P": [-1]}}],
+                            "transition_queries": [{"ch1": {"P": [-1]}}],
                         }
                     ],
                 }


### PR DESCRIPTION
Closes #183 and closes #184

`mrsimulator.method.query.RotationalQuery` -> `mrsimulator.method.query.RotationQuery`

`mrsimulator.method.event.SpectralEvent.transition_query` -> `mrsimulator.method.event.SpectralEvent.transition_queries`