### PR TITLE
STMAS pathway fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         files: \.pyi?$
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
@@ -54,8 +54,7 @@ repos:
         args:
           [
             "--ignore=E402",
-            "--exclude=.eggs, *.egg,build, src/mrsimulator/__init__.py",
-            "--filename=*.pyx, *py",
+            "--exclude=.eggs/,*.egg,build,src/mrsimulator/__init__.py,examples/*",
             "--max-line-length=88",
             "--max-complexity=8",
             "--select=B,C,E,F,W,T,N8",
@@ -64,7 +63,7 @@ repos:
           ]
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.3.0
+    rev: v3.8.2
     hooks:
       - id: reorder-python-imports
         name: Reorder python imports

--- a/src/mrsimulator/method/lib/stvas.py
+++ b/src/mrsimulator/method/lib/stvas.py
@@ -47,13 +47,14 @@ class ST_VAS(BaseNamedMethod2D):
 
         # select the coherence for the first event
         d = st**2 - (st - 1) ** 2
+        p = -1  if st == spin else 1
 
         # setting transition symmetry elements for spectral dimension 0
         events_0 = [
             {
                 "transition_queries": [
-                    {"ch1": {"P": [-1], "D": [d]}},
-                    {"ch1": {"P": [-1], "D": [-d]}},
+                    {"ch1": {"P": [p], "D": [d]}},
+                    {"ch1": {"P": [p], "D": [-d]}},
                 ]
             }
         ]
@@ -62,13 +63,12 @@ class ST_VAS(BaseNamedMethod2D):
 
         # method affine matrix shear factor
         k = shear_factor_ST_MAS[int(2 * st)][spin]
-        sign = 1  # if st == spin else -1
 
         return {
             "name": name,
             "description": description,
             "spectral_dimensions": [{"events": events_0}, {"events": events_1}],
-            "affine_matrix": [1 / (1 + k), sign * k / (1 + k), 0, 1],
+            "affine_matrix": [1 / (1 + k), k / (1 + k), 0, 1],
         }
 
 

--- a/src/mrsimulator/method/lib/stvas.py
+++ b/src/mrsimulator/method/lib/stvas.py
@@ -47,7 +47,7 @@ class ST_VAS(BaseNamedMethod2D):
 
         # select the coherence for the first event
         d = st**2 - (st - 1) ** 2
-        p = -1  if st == spin else 1
+        p = -1 if st == spin else 1
 
         # setting transition symmetry elements for spectral dimension 0
         events_0 = [

--- a/src/mrsimulator/transition/base.py
+++ b/src/mrsimulator/transition/base.py
@@ -9,8 +9,8 @@ __email__ = "srivastava.89@osu.edu"
 
 
 class Transition(Parseable):
-    r"""Base Transition class describes a spin transition between two energy states, where
-    the energy states are described using the weakly coupled basis.
+    r"""Base Transition class describes a spin transition between two energy states,
+    where the energy states are described using the weakly coupled basis.
 
     .. math::
         |m_{i,0}, m_{i,1}, ... m_{i,N} \rangle \rightarrow

--- a/src/mrsimulator/utils/utils.py
+++ b/src/mrsimulator/utils/utils.py
@@ -9,8 +9,8 @@ __email__ = ["srivastava.89@osu.edu", "giammar.7@osu.edu"]
 
 
 def convert_transition_queries(py_dict):
-    """Convert transition_queries->P->... to transition_queries->ch1->P->... if no channel
-    is defined."""
+    """Convert transition_queries->P->... to transition_queries->ch1->P->... if no
+    channel is defined."""
     # check if old structure without channels
     missing_channels = (
         "ch1" not in tq
@@ -222,14 +222,15 @@ def map_p_and_d_symmetry_to_v_7(py_dict):
 #             event[key] = f"{val} {unit}"
 #     return event
 # def _fill_missing_events_in_template(spectral_dimensions, s_template):
-#     """Fill the missing events in the template relative to the spectral dimensions."""
+#     """Fill the missing events in the template relative to the spectral dimension."""
 #     if "events" not in spectral_dimensions:
 #         return
 #     s_tem_len = len(s_template["events"])
 #     sp_evt_len = len(spectral_dimensions["events"])
 #     if s_tem_len < sp_evt_len:
 #         diff = sp_evt_len - s_tem_len
-#         _ = [s_template["events"].append(SpectralEvent().dict()) for _ in range(diff)]
+#         _ = [s_template["events"].append(SpectralEvent().dict()) for _ in range(diff)
+#             ]
 # def _check_rotor_frequency(common, name, kwargs):
 #     if common == set():
 #         return

--- a/tests/2D_spectrum_tests/test_stmas.py
+++ b/tests/2D_spectrum_tests/test_stmas.py
@@ -1,0 +1,93 @@
+import numpy as np
+from mrsimulator import Simulator
+from mrsimulator import Site
+from mrsimulator import SpinSystem
+from mrsimulator.method import Method
+from mrsimulator.method import SpectralDimension
+from mrsimulator.method.event import SpectralEvent
+from mrsimulator.method.lib import ST1_VAS
+
+
+def test_ST_VAS_isotropic_shift():
+    Co59 = Site(
+        isotope="59Co",
+        isotropic_chemical_shift=-27.4,  # in ppm
+        quadrupolar=dict(Cq=1.68e6, eta=0.2),  # Cq is in Hz
+    )
+
+    dim_kwargs = [
+        dict(count=512, spectral_width=2e3, reference_offset=0),
+        dict(count=512, spectral_width=1e3, reference_offset=-2e3),
+    ]
+
+    spin_systems = [SpinSystem(sites=[Co59])]
+    method_2d = ST1_VAS(
+        channels=["59Co"],
+        magnetic_flux_density=7,  # in T
+        rotor_angle=54.7359 * 3.14159 / 180,
+        spectral_dimensions=[
+            SpectralDimension(**dim_kwargs[0]),
+            SpectralDimension(**dim_kwargs[1]),
+        ],
+    )
+    method_1d_iso = Method(
+        channels=["59Co"],
+        magnetic_flux_density=7,  # in T
+        rotor_angle=54.7359 * 3.14159 / 180,
+        rotor_frequency=np.inf,
+        spectral_dimensions=[
+            SpectralDimension(
+                **dim_kwargs[0],
+                events=[
+                    SpectralEvent(
+                        fraction=1 / (1 + (84 / 135)),
+                        freq_contrib=["Shielding1_0", "Quad2_0"],
+                        transition_queries=[
+                            {"ch1": {"P": [1], "D": [2]}},
+                            {"ch1": {"P": [1], "D": [-2]}},
+                        ],
+                    ),
+                    SpectralEvent(
+                        fraction=(84 / 135) / (1 + (84 / 135)),
+                        freq_contrib=["Shielding1_0", "Quad2_0"],
+                        transition_queries=[{"ch1": {"P": [-1], "D": [0]}}],
+                    ),
+                ]
+            ),
+        ],
+    )
+    method_1d_ct = Method(
+        channels=["59Co"],
+        magnetic_flux_density=7,  # in T
+        rotor_angle=54.7359 * 3.14159 / 180,
+        rotor_frequency=np.inf,
+        spectral_dimensions=[
+            SpectralDimension(
+                **dim_kwargs[1],
+                events=[
+                    SpectralEvent(transition_queries=[{"ch1": {"P": [-1], "D": [0]}}])
+                ]
+            ),
+        ],
+    )
+    methods = [method_2d, method_1d_iso, method_1d_ct]
+
+    sim = Simulator(spin_systems=spin_systems, methods=methods)
+    sim.run()
+
+    dataset_proj_iso = sim.methods[0].simulation.sum(axis=0)
+    dataset_proj_ct = sim.methods[0].simulation.sum(axis=1)
+    dataset_iso = sim.methods[1].simulation
+    dataset_ct = sim.methods[2].simulation
+
+    # check isotropic freq is the same
+    m1 = np.argmax(dataset_proj_iso.y[0].components[0])
+    m2 = np.argmax(dataset_iso.y[0].components[0])
+    assert m1 == m2
+
+    # check the quad CT spectrum is same.
+    ct_proj = dataset_proj_ct.y[0].components[0]
+    ct_spec = dataset_ct.y[0].components[0]
+    np.testing.assert_almost_equal(
+        ct_proj / ct_proj.sum(), ct_spec / ct_spec.sum(), decimal=8
+    )


### PR DESCRIPTION
I noticed that you get a divide by zero error if you apply an affine transform on a spectrum of all zeros.  That is, if you have the wrong spectral width so that the spectrum is outside the window, then the affine gives an error.