### PR TITLE
Store spin_multiplicity instead of spin for all Isotopes

### DIFF
--- a/src/mrsimulator/spin_system/__init__.py
+++ b/src/mrsimulator/spin_system/__init__.py
@@ -487,6 +487,6 @@ def allowed_isotopes(spin_I: float = None) -> list:
         {
             isotope
             for isotope, data in ISOTOPE_DATA.items()
-            if data["spin"] == int(2 * spin_I)
+            if data["spin_multiplicity"] == int(2 * spin_I + 1)  # 2S+1
         }
     )

--- a/src/mrsimulator/spin_system/isotope.py
+++ b/src/mrsimulator/spin_system/isotope.py
@@ -59,7 +59,7 @@ class Isotope(BaseModel):
     def spin(self):
         """Spin quantum number, I, of the isotope."""
         isotope_data = get_isotope_data(self.symbol)
-        return isotope_data["spin"] / 2.0
+        return (isotope_data["spin_multiplicity"] - 1) / 2.0
 
     @property
     def natural_abundance(self):

--- a/src/mrsimulator/spin_system/isotope_data.json
+++ b/src/mrsimulator/spin_system/isotope_data.json
@@ -1,4468 +1,4468 @@
 {
   "1H": {
-    "spin": 1,
     "natural_abundance": 99.985,
     "gyromagnetic_ratio": 42.57747920984721,
     "quadrupole_moment": 0.0,
-    "atomic_number": 1
+    "atomic_number": 1,
+    "spin_multiplicity": 2
   },
   "2H": {
-    "spin": 2,
     "natural_abundance": 0.015,
     "gyromagnetic_ratio": 6.5359028463694875,
     "quadrupole_moment": 0.00286,
-    "atomic_number": 1
+    "atomic_number": 1,
+    "spin_multiplicity": 3
   },
   "3H": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 45.41483845958189,
     "quadrupole_moment": 0.0,
-    "atomic_number": 1
+    "atomic_number": 1,
+    "spin_multiplicity": 2
   },
   "3He": {
-    "spin": 1,
     "natural_abundance": 0.000137,
     "gyromagnetic_ratio": -32.436037551349806,
     "quadrupole_moment": 0.0,
-    "atomic_number": 2
+    "atomic_number": 2,
+    "spin_multiplicity": 2
   },
   "6Li": {
-    "spin": 2,
     "natural_abundance": 7.59,
     "gyromagnetic_ratio": 6.266132182979937,
     "quadrupole_moment": -0.00083,
-    "atomic_number": 3
+    "atomic_number": 3,
+    "spin_multiplicity": 3
   },
   "7Li": {
-    "spin": 3,
     "natural_abundance": 92.41,
     "gyromagnetic_ratio": 16.548277917826518,
     "quadrupole_moment": -0.0406,
-    "atomic_number": 3
+    "atomic_number": 3,
+    "spin_multiplicity": 4
   },
   "8Li": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.302207629955297,
     "quadrupole_moment": 0.0317,
-    "atomic_number": 3
+    "atomic_number": 3,
+    "spin_multiplicity": 5
   },
   "9Li": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 17.476573582798537,
     "quadrupole_moment": 0.0278,
-    "atomic_number": 3
+    "atomic_number": 3,
+    "spin_multiplicity": 4
   },
   "11Li": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 18.638764963795317,
     "quadrupole_moment": 0.0,
-    "atomic_number": 3
+    "atomic_number": 3,
+    "spin_multiplicity": 4
   },
   "9Be": {
-    "spin": 3,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": -5.985260203489319,
     "quadrupole_moment": 0.053,
-    "atomic_number": 4
+    "atomic_number": 4,
+    "spin_multiplicity": 4
   },
   "8B": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.946597644366525,
     "quadrupole_moment": 0.0,
-    "atomic_number": 5
+    "atomic_number": 5,
+    "spin_multiplicity": 5
   },
   "10B": {
-    "spin": 6,
     "natural_abundance": 19.8,
     "gyromagnetic_ratio": 4.5751942868313735,
     "quadrupole_moment": 0.08472,
-    "atomic_number": 5
+    "atomic_number": 5,
+    "spin_multiplicity": 7
   },
   "11B": {
-    "spin": 3,
     "natural_abundance": 80.2,
     "gyromagnetic_ratio": 13.662984600378108,
     "quadrupole_moment": 0.04065,
-    "atomic_number": 5
+    "atomic_number": 5,
+    "spin_multiplicity": 4
   },
   "12B": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.645918364381046,
     "quadrupole_moment": 0.0134,
-    "atomic_number": 5
+    "atomic_number": 5,
+    "spin_multiplicity": 3
   },
   "13B": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 16.14871784228932,
     "quadrupole_moment": 0.037,
-    "atomic_number": 5
+    "atomic_number": 5,
+    "spin_multiplicity": 4
   },
   "11C": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -4.898786581901599,
     "quadrupole_moment": 0.03426,
-    "atomic_number": 6
+    "atomic_number": 6,
+    "spin_multiplicity": 4
   },
   "13C": {
-    "spin": 1,
     "natural_abundance": 1.11,
     "gyromagnetic_ratio": 10.708398861439887,
     "quadrupole_moment": 0.0,
-    "atomic_number": 6
+    "atomic_number": 6,
+    "spin_multiplicity": 2
   },
   "15C": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 20.123646124824,
     "quadrupole_moment": 0.0,
-    "atomic_number": 6
+    "atomic_number": 6,
+    "spin_multiplicity": 2
   },
   "12N": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.48581188366743,
     "quadrupole_moment": 0.026,
-    "atomic_number": 7
+    "atomic_number": 7,
+    "spin_multiplicity": 3
   },
   "13N": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.911999076832039,
     "quadrupole_moment": 0.0,
-    "atomic_number": 7
+    "atomic_number": 7,
+    "spin_multiplicity": 2
   },
   "14N": {
-    "spin": 2,
     "natural_abundance": 99.634,
     "gyromagnetic_ratio": 3.0777058647746447,
     "quadrupole_moment": 0.0193,
-    "atomic_number": 7
+    "atomic_number": 7,
+    "spin_multiplicity": 3
   },
   "15N": {
-    "spin": 1,
     "natural_abundance": 0.366,
     "gyromagnetic_ratio": -4.317266668681366,
     "quadrupole_moment": 0.0,
-    "atomic_number": 7
+    "atomic_number": 7,
+    "spin_multiplicity": 2
   },
   "15O": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.95976454479998,
     "quadrupole_moment": 0.0,
-    "atomic_number": 8
+    "atomic_number": 8,
+    "spin_multiplicity": 2
   },
   "17O": {
-    "spin": 5,
     "natural_abundance": 0.038,
     "gyromagnetic_ratio": -5.774236332534915,
     "quadrupole_moment": -0.02578,
-    "atomic_number": 8
+    "atomic_number": 8,
+    "spin_multiplicity": 6
   },
   "17F": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 14.395419765019932,
     "quadrupole_moment": 0.058,
-    "atomic_number": 9
+    "atomic_number": 9,
+    "spin_multiplicity": 6
   },
   "19F": {
-    "spin": 1,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 40.077582833995315,
     "quadrupole_moment": 0.0,
-    "atomic_number": 9
+    "atomic_number": 9,
+    "spin_multiplicity": 2
   },
   "20F": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.978949462560425,
     "quadrupole_moment": 0.042,
-    "atomic_number": 9
+    "atomic_number": 9,
+    "spin_multiplicity": 5
   },
   "19Ne": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -28.743579452019443,
     "quadrupole_moment": 0.0,
-    "atomic_number": 10
+    "atomic_number": 10,
+    "spin_multiplicity": 2
   },
   "21Ne": {
-    "spin": 3,
     "natural_abundance": 0.27,
     "gyromagnetic_ratio": -3.363072887492461,
     "quadrupole_moment": 0.103,
-    "atomic_number": 10
+    "atomic_number": 10,
+    "spin_multiplicity": 4
   },
   "23Ne": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.2929602749712,
     "quadrupole_moment": 0.0,
-    "atomic_number": 10
+    "atomic_number": 10,
+    "spin_multiplicity": 6
   },
   "20Na": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.40789296941477,
     "quadrupole_moment": 0.0,
-    "atomic_number": 11
+    "atomic_number": 11,
+    "spin_multiplicity": 5
   },
   "21Na": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 12.126529481734218,
     "quadrupole_moment": 0.05,
-    "atomic_number": 11
+    "atomic_number": 11,
+    "spin_multiplicity": 4
   },
   "22Na": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.4363492593361995,
     "quadrupole_moment": 0.0,
-    "atomic_number": 11
+    "atomic_number": 11,
+    "spin_multiplicity": 7
   },
   "23Na": {
-    "spin": 3,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 11.268835291595886,
     "quadrupole_moment": 0.1006,
-    "atomic_number": 11
+    "atomic_number": 11,
+    "spin_multiplicity": 4
   },
   "24Na": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.2211173337869323,
     "quadrupole_moment": 0.0,
-    "atomic_number": 11
+    "atomic_number": 11,
+    "spin_multiplicity": 9
   },
   "25Na": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.229604345110118,
     "quadrupole_moment": -0.1,
-    "atomic_number": 11
+    "atomic_number": 11,
+    "spin_multiplicity": 6
   },
   "26Na": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.244004432054699,
     "quadrupole_moment": -0.08,
-    "atomic_number": 11
+    "atomic_number": 11,
+    "spin_multiplicity": 7
   },
   "27Na": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.8760002509378,
     "quadrupole_moment": -0.06,
-    "atomic_number": 11
+    "atomic_number": 11,
+    "spin_multiplicity": 6
   },
   "28Na": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 18.4924111737966,
     "quadrupole_moment": -0.02,
-    "atomic_number": 11
+    "atomic_number": 11,
+    "spin_multiplicity": 3
   },
   "29Na": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 12.445153878710597,
     "quadrupole_moment": 0.03,
-    "atomic_number": 11
+    "atomic_number": 11,
+    "spin_multiplicity": 4
   },
   "30Na": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.93893084810765,
     "quadrupole_moment": 0.0,
-    "atomic_number": 11
+    "atomic_number": 11,
+    "spin_multiplicity": 5
   },
   "31Na": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.713384928717,
     "quadrupole_moment": 0.0,
-    "atomic_number": 11
+    "atomic_number": 11,
+    "spin_multiplicity": 4
   },
   "25Mg": {
-    "spin": 5,
     "natural_abundance": 10.0,
     "gyromagnetic_ratio": -2.6082989511334382,
     "quadrupole_moment": 0.201,
-    "atomic_number": 12
+    "atomic_number": 12,
+    "spin_multiplicity": 6
   },
   "25Al": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.11526544667362,
     "quadrupole_moment": 0.0,
-    "atomic_number": 13
+    "atomic_number": 13,
+    "spin_multiplicity": 6
   },
   "27Al": {
-    "spin": 5,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 11.103090335864373,
     "quadrupole_moment": 0.15,
-    "atomic_number": 13
+    "atomic_number": 13,
+    "spin_multiplicity": 6
   },
   "28Al": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.2374824162474,
     "quadrupole_moment": 0.175,
-    "atomic_number": 13
+    "atomic_number": 13,
+    "spin_multiplicity": 7
   },
   "27Si": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.608146499268856,
     "quadrupole_moment": 0.0,
-    "atomic_number": 14
+    "atomic_number": 14,
+    "spin_multiplicity": 6
   },
   "29Si": {
-    "spin": 1,
     "natural_abundance": 4.683,
     "gyromagnetic_ratio": -8.465499588373877,
     "quadrupole_moment": 0.0,
-    "atomic_number": 14
+    "atomic_number": 14,
+    "spin_multiplicity": 2
   },
   "29P": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 18.82628075723118,
     "quadrupole_moment": 0.0,
-    "atomic_number": 15
+    "atomic_number": 15,
+    "spin_multiplicity": 2
   },
   "31P": {
-    "spin": 1,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 17.25145299609912,
     "quadrupole_moment": 0.0,
-    "atomic_number": 15
+    "atomic_number": 15,
+    "spin_multiplicity": 2
   },
   "32P": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.92394253102484,
     "quadrupole_moment": 0.0,
-    "atomic_number": 15
+    "atomic_number": 15,
+    "spin_multiplicity": 3
   },
   "31S": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.438583828549525,
     "quadrupole_moment": 0.0,
-    "atomic_number": 16
+    "atomic_number": 16,
+    "spin_multiplicity": 2
   },
   "33S": {
-    "spin": 3,
     "natural_abundance": 0.75,
     "gyromagnetic_ratio": 3.271724746580691,
     "quadrupole_moment": -0.076,
-    "atomic_number": 16
+    "atomic_number": 16,
+    "spin_multiplicity": 4
   },
   "33Cl": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.8229845908346194,
     "quadrupole_moment": 0.0,
-    "atomic_number": 17
+    "atomic_number": 17,
+    "spin_multiplicity": 4
   },
   "35Cl": {
-    "spin": 3,
     "natural_abundance": 75.77000000000001,
     "gyromagnetic_ratio": 4.176542316234201,
     "quadrupole_moment": -0.08249,
-    "atomic_number": 17
+    "atomic_number": 17,
+    "spin_multiplicity": 4
   },
   "36Cl": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.899307459105588,
     "quadrupole_moment": -0.018,
-    "atomic_number": 17
+    "atomic_number": 17,
+    "spin_multiplicity": 5
   },
   "37Cl": {
-    "spin": 3,
     "natural_abundance": 24.23,
     "gyromagnetic_ratio": 3.476530614151678,
     "quadrupole_moment": -0.06493,
-    "atomic_number": 17
+    "atomic_number": 17,
+    "spin_multiplicity": 4
   },
   "38Cl": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.813158059827499,
     "quadrupole_moment": 0.0,
-    "atomic_number": 17
+    "atomic_number": 17,
+    "spin_multiplicity": 5
   },
   "35Ar": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.2167343426801995,
     "quadrupole_moment": 0.0,
-    "atomic_number": 18
+    "atomic_number": 18,
+    "spin_multiplicity": 4
   },
   "37Ar": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.8185794982129995,
     "quadrupole_moment": 0.0,
-    "atomic_number": 18
+    "atomic_number": 18,
+    "spin_multiplicity": 4
   },
   "39Ar": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.831248913665714,
     "quadrupole_moment": 0.0,
-    "atomic_number": 18
+    "atomic_number": 18,
+    "spin_multiplicity": 8
   },
   "36K": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.0885905447734,
     "quadrupole_moment": 0.0,
-    "atomic_number": 19
+    "atomic_number": 19,
+    "spin_multiplicity": 5
   },
   "37K": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.032658113390274,
     "quadrupole_moment": 0.0,
-    "atomic_number": 19
+    "atomic_number": 19,
+    "spin_multiplicity": 4
   },
   "38K": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.4835251056986998,
     "quadrupole_moment": 0.0,
-    "atomic_number": 19
+    "atomic_number": 19,
+    "spin_multiplicity": 7
   },
   "39K": {
-    "spin": 3,
     "natural_abundance": 93.2581,
     "gyromagnetic_ratio": 1.989325070361004,
     "quadrupole_moment": 0.049,
-    "atomic_number": 19
+    "atomic_number": 19,
+    "spin_multiplicity": 4
   },
   "40K": {
-    "spin": 8,
     "natural_abundance": 0.0117,
     "gyromagnetic_ratio": -2.4737220676736773,
     "quadrupole_moment": -0.061,
-    "atomic_number": 19
+    "atomic_number": 19,
+    "spin_multiplicity": 9
   },
   "41K": {
-    "spin": 3,
     "natural_abundance": 6.7302,
     "gyromagnetic_ratio": 1.09191157959736,
     "quadrupole_moment": 0.06,
-    "atomic_number": 19
+    "atomic_number": 19,
+    "spin_multiplicity": 4
   },
   "42K": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -4.354406382123375,
     "quadrupole_moment": 0.0,
-    "atomic_number": 19
+    "atomic_number": 19,
+    "spin_multiplicity": 5
   },
   "43K": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.82984631620802,
     "quadrupole_moment": 0.0,
-    "atomic_number": 19
+    "atomic_number": 19,
+    "spin_multiplicity": 4
   },
   "44K": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.2624699020547996,
     "quadrupole_moment": 0.0,
-    "atomic_number": 19
+    "atomic_number": 19,
+    "spin_multiplicity": 5
   },
   "45K": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.8811717772839599,
     "quadrupole_moment": 0.0,
-    "atomic_number": 19
+    "atomic_number": 19,
+    "spin_multiplicity": 4
   },
   "46K": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -4.00567274189205,
     "quadrupole_moment": 0.0,
-    "atomic_number": 19
+    "atomic_number": 19,
+    "spin_multiplicity": 5
   },
   "47K": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 29.4689454237006,
     "quadrupole_moment": 0.0,
-    "atomic_number": 19
+    "atomic_number": 19,
+    "spin_multiplicity": 2
   },
   "39Ca": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.191900700204591,
     "quadrupole_moment": 0.0,
-    "atomic_number": 20
+    "atomic_number": 20,
+    "spin_multiplicity": 4
   },
   "41Ca": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.4732476721420933,
     "quadrupole_moment": -0.08,
-    "atomic_number": 20
+    "atomic_number": 20,
+    "spin_multiplicity": 8
   },
   "43Ca": {
-    "spin": 7,
     "natural_abundance": 0.135,
     "gyromagnetic_ratio": -2.869673317191717,
     "quadrupole_moment": -0.049,
-    "atomic_number": 20
+    "atomic_number": 20,
+    "spin_multiplicity": 8
   },
   "45Ca": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.890922929230668,
     "quadrupole_moment": 0.046,
-    "atomic_number": 20
+    "atomic_number": 20,
+    "spin_multiplicity": 8
   },
   "47Ca": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.0054796160451422,
     "quadrupole_moment": 0.021,
-    "atomic_number": 20
+    "atomic_number": 20,
+    "spin_multiplicity": 8
   },
   "41Sc": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 12.054586720876713,
     "quadrupole_moment": 0.0,
-    "atomic_number": 21
+    "atomic_number": 21,
+    "spin_multiplicity": 8
   },
   "43Sc": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.061823062412,
     "quadrupole_moment": -0.26,
-    "atomic_number": 21
+    "atomic_number": 21,
+    "spin_multiplicity": 8
   },
   "44Sc": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.756919333248,
     "quadrupole_moment": 0.1,
-    "atomic_number": 21
+    "atomic_number": 21,
+    "spin_multiplicity": 5
   },
   "45Sc": {
-    "spin": 7,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 10.35907501470425,
     "quadrupole_moment": -0.22,
-    "atomic_number": 21
+    "atomic_number": 21,
+    "spin_multiplicity": 8
   },
   "46Sc": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.774114371043249,
     "quadrupole_moment": 0.119,
-    "atomic_number": 21
+    "atomic_number": 21,
+    "spin_multiplicity": 9
   },
   "47Sc": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.629899383826857,
     "quadrupole_moment": -0.22,
-    "atomic_number": 21
+    "atomic_number": 21,
+    "spin_multiplicity": 8
   },
   "43Ti": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.5245186458199997,
     "quadrupole_moment": 0.0,
-    "atomic_number": 22
+    "atomic_number": 22,
+    "spin_multiplicity": 8
   },
   "45Ti": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.2068989590755714,
     "quadrupole_moment": 0.015,
-    "atomic_number": 22
+    "atomic_number": 22,
+    "spin_multiplicity": 8
   },
   "47Ti": {
-    "spin": 5,
     "natural_abundance": 7.4399999999999995,
     "gyromagnetic_ratio": -2.404104923712307,
     "quadrupole_moment": 0.29,
-    "atomic_number": 22
+    "atomic_number": 22,
+    "spin_multiplicity": 6
   },
   "49Ti": {
-    "spin": 7,
     "natural_abundance": 5.41,
     "gyromagnetic_ratio": -2.4047539330786707,
     "quadrupole_moment": 0.24,
-    "atomic_number": 22
+    "atomic_number": 22,
+    "spin_multiplicity": 8
   },
   "48V": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.8341643942372996,
     "quadrupole_moment": 0.0,
-    "atomic_number": 23
+    "atomic_number": 23,
+    "spin_multiplicity": 9
   },
   "49V": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.73514049545057,
     "quadrupole_moment": 0.0,
-    "atomic_number": 23
+    "atomic_number": 23,
+    "spin_multiplicity": 8
   },
   "50V": {
-    "spin": 12,
     "natural_abundance": 0.25,
     "gyromagnetic_ratio": 4.250470925969171,
     "quadrupole_moment": 0.209,
-    "atomic_number": 23
+    "atomic_number": 23,
+    "spin_multiplicity": 13
   },
   "51V": {
-    "spin": 7,
     "natural_abundance": 99.75,
     "gyromagnetic_ratio": 11.213282696036105,
     "quadrupole_moment": -0.052,
-    "atomic_number": 23
+    "atomic_number": 23,
+    "spin_multiplicity": 8
   },
   "49Cr": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.4513417508206399,
     "quadrupole_moment": 0.0,
-    "atomic_number": 24
+    "atomic_number": 24,
+    "spin_multiplicity": 6
   },
   "51Cr": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.0341434502798283,
     "quadrupole_moment": 0.0,
-    "atomic_number": 24
+    "atomic_number": 24,
+    "spin_multiplicity": 8
   },
   "53Cr": {
-    "spin": 3,
     "natural_abundance": 9.501,
     "gyromagnetic_ratio": -2.4114835939580757,
     "quadrupole_moment": -0.15,
-    "atomic_number": 24
+    "atomic_number": 24,
+    "spin_multiplicity": 4
   },
   "51Mn": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.879879767759011,
     "quadrupole_moment": 0.42,
-    "atomic_number": 25
+    "atomic_number": 25,
+    "spin_multiplicity": 6
   },
   "52Mn": {
-    "spin": 12,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.8903174976916692,
     "quadrupole_moment": 0.5,
-    "atomic_number": 25
+    "atomic_number": 25,
+    "spin_multiplicity": 13
   },
   "53Mn": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.941688109428114,
     "quadrupole_moment": 0.0,
-    "atomic_number": 25
+    "atomic_number": 25,
+    "spin_multiplicity": 8
   },
   "54Mn": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.338862906194429,
     "quadrupole_moment": 0.33,
-    "atomic_number": 25
+    "atomic_number": 25,
+    "spin_multiplicity": 7
   },
   "55Mn": {
-    "spin": 5,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 10.528935575491246,
     "quadrupole_moment": 0.33,
-    "atomic_number": 25
+    "atomic_number": 25,
+    "spin_multiplicity": 6
   },
   "56Mn": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.198353104338018,
     "quadrupole_moment": 0.0,
-    "atomic_number": 25
+    "atomic_number": 25,
+    "spin_multiplicity": 7
   },
   "57Fe": {
-    "spin": 1,
     "natural_abundance": 2.119,
     "gyromagnetic_ratio": 1.378774663279608,
     "quadrupole_moment": 0.0,
-    "atomic_number": 26
+    "atomic_number": 26,
+    "spin_multiplicity": 2
   },
   "59Fe": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.4737013576259996,
     "quadrupole_moment": 0.0,
-    "atomic_number": 26
+    "atomic_number": 26,
+    "spin_multiplicity": 4
   },
   "55Co": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.501755585920057,
     "quadrupole_moment": 0.0,
-    "atomic_number": 27
+    "atomic_number": 27,
+    "spin_multiplicity": 8
   },
   "56Co": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.338651631316025,
     "quadrupole_moment": 0.25,
-    "atomic_number": 27
+    "atomic_number": 27,
+    "spin_multiplicity": 9
   },
   "57Co": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.279611440386285,
     "quadrupole_moment": 0.52,
-    "atomic_number": 27
+    "atomic_number": 27,
+    "spin_multiplicity": 8
   },
   "58Co": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 15.412883509240197,
     "quadrupole_moment": 0.22,
-    "atomic_number": 27
+    "atomic_number": 27,
+    "spin_multiplicity": 5
   },
   "59Co": {
-    "spin": 7,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 10.077068248870198,
     "quadrupole_moment": 0.404,
-    "atomic_number": 27
+    "atomic_number": 27,
+    "spin_multiplicity": 8
   },
   "60Co": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.79164633547018,
     "quadrupole_moment": 0.44,
-    "atomic_number": 27
+    "atomic_number": 27,
+    "spin_multiplicity": 11
   },
   "57Ni": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.471921361072,
     "quadrupole_moment": 0.0,
-    "atomic_number": 28
+    "atomic_number": 28,
+    "spin_multiplicity": 4
   },
   "61Ni": {
-    "spin": 3,
     "natural_abundance": 1.1400000000000001,
     "gyromagnetic_ratio": -3.8113982491263876,
     "quadrupole_moment": 0.162,
-    "atomic_number": 28
+    "atomic_number": 28,
+    "spin_multiplicity": 4
   },
   "65Ni": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.1038357312316,
     "quadrupole_moment": 0.0,
-    "atomic_number": 28
+    "atomic_number": 28,
+    "spin_multiplicity": 6
   },
   "60Cu": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.6459705731364505,
     "quadrupole_moment": 0.0,
-    "atomic_number": 29
+    "atomic_number": 29,
+    "spin_multiplicity": 5
   },
   "61Cu": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.874899673516,
     "quadrupole_moment": 0.0,
-    "atomic_number": 29
+    "atomic_number": 29,
+    "spin_multiplicity": 4
   },
   "62Cu": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.896585427058,
     "quadrupole_moment": 0.0,
-    "atomic_number": 29
+    "atomic_number": 29,
+    "spin_multiplicity": 3
   },
   "63Cu": {
-    "spin": 3,
     "natural_abundance": 69.17,
     "gyromagnetic_ratio": 11.298156866883824,
     "quadrupole_moment": -0.211,
-    "atomic_number": 29
+    "atomic_number": 29,
+    "spin_multiplicity": 4
   },
   "64Cu": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.6541027307146998,
     "quadrupole_moment": 0.0,
-    "atomic_number": 29
+    "atomic_number": 29,
+    "spin_multiplicity": 3
   },
   "65Cu": {
-    "spin": 3,
     "natural_abundance": 30.830000000000002,
     "gyromagnetic_ratio": 12.103001077300398,
     "quadrupole_moment": -0.195,
-    "atomic_number": 29
+    "atomic_number": 29,
+    "spin_multiplicity": 4
   },
   "66Cu": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.1495712906062,
     "quadrupole_moment": 0.0,
-    "atomic_number": 29
+    "atomic_number": 29,
+    "spin_multiplicity": 3
   },
   "63Zn": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.431218104695816,
     "quadrupole_moment": 0.29,
-    "atomic_number": 30
+    "atomic_number": 30,
+    "spin_multiplicity": 4
   },
   "65Zn": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.34470967727116,
     "quadrupole_moment": -0.023,
-    "atomic_number": 30
+    "atomic_number": 30,
+    "spin_multiplicity": 6
   },
   "67Zn": {
-    "spin": 5,
     "natural_abundance": 4.1000000000000005,
     "gyromagnetic_ratio": 2.6693681190476957,
     "quadrupole_moment": 0.15,
-    "atomic_number": 30
+    "atomic_number": 30,
+    "spin_multiplicity": 6
   },
   "67Ga": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.404755526063578,
     "quadrupole_moment": 0.195,
-    "atomic_number": 31
+    "atomic_number": 31,
+    "spin_multiplicity": 4
   },
   "68Ga": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.08956547044192499,
     "quadrupole_moment": 0.0277,
-    "atomic_number": 31
+    "atomic_number": 31,
+    "spin_multiplicity": 3
   },
   "69Ga": {
-    "spin": 3,
     "natural_abundance": 60.108,
     "gyromagnetic_ratio": 10.247763519913844,
     "quadrupole_moment": 0.168,
-    "atomic_number": 31
+    "atomic_number": 31,
+    "spin_multiplicity": 4
   },
   "71Ga": {
-    "spin": 3,
     "natural_abundance": 39.892,
     "gyromagnetic_ratio": 13.02074097516876,
     "quadrupole_moment": 0.106,
-    "atomic_number": 31
+    "atomic_number": 31,
+    "spin_multiplicity": 4
   },
   "72Ga": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -0.33600390953872794,
     "quadrupole_moment": 0.52,
-    "atomic_number": 31
+    "atomic_number": 31,
+    "spin_multiplicity": 7
   },
   "69Ge": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.2410424093554,
     "quadrupole_moment": 0.024,
-    "atomic_number": 32
+    "atomic_number": 32,
+    "spin_multiplicity": 6
   },
   "71Ge": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.3391169926354,
     "quadrupole_moment": 0.0,
-    "atomic_number": 32
+    "atomic_number": 32,
+    "spin_multiplicity": 2
   },
   "73Ge": {
-    "spin": 9,
     "natural_abundance": 7.76,
     "gyromagnetic_ratio": -1.4897387856071442,
     "quadrupole_moment": -0.173,
-    "atomic_number": 32
+    "atomic_number": 32,
+    "spin_multiplicity": 10
   },
   "75Ge": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.7750450936819995,
     "quadrupole_moment": 0.0,
-    "atomic_number": 32
+    "atomic_number": 32,
+    "spin_multiplicity": 2
   },
   "69As": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.658844749968,
     "quadrupole_moment": 0.0,
-    "atomic_number": 33
+    "atomic_number": 33,
+    "spin_multiplicity": 6
   },
   "70As": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.013485899951878,
     "quadrupole_moment": 0.094,
-    "atomic_number": 33
+    "atomic_number": 33,
+    "spin_multiplicity": 9
   },
   "71As": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.1025639075595395,
     "quadrupole_moment": -0.021,
-    "atomic_number": 33
+    "atomic_number": 33,
+    "spin_multiplicity": 6
   },
   "72As": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -8.21944227893853,
     "quadrupole_moment": -0.082,
-    "atomic_number": 33
+    "atomic_number": 33,
+    "spin_multiplicity": 5
   },
   "74As": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -6.086640693436349,
     "quadrupole_moment": 0.0,
-    "atomic_number": 33
+    "atomic_number": 33,
+    "spin_multiplicity": 5
   },
   "75As": {
-    "spin": 3,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 7.314996183661718,
     "quadrupole_moment": 0.314,
-    "atomic_number": 33
+    "atomic_number": 33,
+    "spin_multiplicity": 4
   },
   "76As": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.4530347327823,
     "quadrupole_moment": 7.0,
-    "atomic_number": 33
+    "atomic_number": 33,
+    "spin_multiplicity": 5
   },
   "73Se": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.4737013576259999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 34
+    "atomic_number": 34,
+    "spin_multiplicity": 10
   },
   "75Se": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.0428549853988,
     "quadrupole_moment": 1.0,
-    "atomic_number": 34
+    "atomic_number": 34,
+    "spin_multiplicity": 6
   },
   "77Se": {
-    "spin": 1,
     "natural_abundance": 7.630000000000001,
     "gyromagnetic_ratio": 8.156818102005536,
     "quadrupole_moment": 0.0,
-    "atomic_number": 34
+    "atomic_number": 34,
+    "spin_multiplicity": 2
   },
   "79Se": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.2170856877782286,
     "quadrupole_moment": 0.8,
-    "atomic_number": 34
+    "atomic_number": 34,
+    "spin_multiplicity": 8
   },
   "75Br": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.81129661455,
     "quadrupole_moment": 0.0,
-    "atomic_number": 35
+    "atomic_number": 35,
+    "spin_multiplicity": 4
   },
   "76Br": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -4.17878183412491,
     "quadrupole_moment": 0.27,
-    "atomic_number": 35
+    "atomic_number": 35,
+    "spin_multiplicity": 3
   },
   "77Br": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.675190513847999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 35
+    "atomic_number": 35,
+    "spin_multiplicity": 4
   },
   "79Br": {
-    "spin": 3,
     "natural_abundance": 50.690000000000005,
     "gyromagnetic_ratio": 10.704153585184159,
     "quadrupole_moment": 0.331,
-    "atomic_number": 35
+    "atomic_number": 35,
+    "spin_multiplicity": 4
   },
   "80Br": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.9180129197574,
     "quadrupole_moment": 0.196,
-    "atomic_number": 35
+    "atomic_number": 35,
+    "spin_multiplicity": 3
   },
   "81Br": {
-    "spin": 3,
     "natural_abundance": 49.309999999999995,
     "gyromagnetic_ratio": 11.538380351634501,
     "quadrupole_moment": 0.276,
-    "atomic_number": 35
+    "atomic_number": 35,
+    "spin_multiplicity": 4
   },
   "82Br": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.4803918367491398,
     "quadrupole_moment": 0.751,
-    "atomic_number": 35
+    "atomic_number": 35,
+    "spin_multiplicity": 11
   },
   "83Kr": {
-    "spin": 9,
     "natural_abundance": 11.49,
     "gyromagnetic_ratio": -1.6442255437993927,
     "quadrupole_moment": 0.253,
-    "atomic_number": 36
+    "atomic_number": 36,
+    "spin_multiplicity": 10
   },
   "85Kr": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.6939096064666666,
     "quadrupole_moment": 0.433,
-    "atomic_number": 36
+    "atomic_number": 36,
+    "spin_multiplicity": 10
   },
   "87Kr": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.10391996288952,
     "quadrupole_moment": 0.0,
-    "atomic_number": 36
+    "atomic_number": 36,
+    "spin_multiplicity": 6
   },
   "93Kr": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -6.09807458328,
     "quadrupole_moment": 0.0,
-    "atomic_number": 36
+    "atomic_number": 36,
+    "spin_multiplicity": 2
   },
   "76Rb": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.8403520322882834,
     "quadrupole_moment": 0.38,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 3
   },
   "77Rb": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.325828896975079,
     "quadrupole_moment": 0.7,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 4
   },
   "79Rb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.238362321597956,
     "quadrupole_moment": -0.098,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 6
   },
   "80Rb": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -0.6372487939527599,
     "quadrupole_moment": 0.348,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 3
   },
   "81Rb": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.465820503554298,
     "quadrupole_moment": 0.398,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 4
   },
   "82Rb": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.226791213059751,
     "quadrupole_moment": 0.19,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 3
   },
   "83Rb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.344573236857836,
     "quadrupole_moment": 0.196,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 6
   },
   "84Rb": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -5.046598828071488,
     "quadrupole_moment": -0.015,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 5
   },
   "85Rb": {
-    "spin": 5,
     "natural_abundance": 72.17,
     "gyromagnetic_ratio": 4.1264191921969315,
     "quadrupole_moment": 0.23,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 6
   },
   "86Rb": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -6.448713871818599,
     "quadrupole_moment": 0.19,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 5
   },
   "87Rb": {
-    "spin": 3,
     "natural_abundance": 27.83,
     "gyromagnetic_ratio": 13.983992836343669,
     "quadrupole_moment": 0.127,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 4
   },
   "88Rb": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.9361386801914,
     "quadrupole_moment": -0.0,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 5
   },
   "91Rb": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.0857914195211,
     "quadrupole_moment": 0.154,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 4
   },
   "93Rb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.297618062566579,
     "quadrupole_moment": 0.18,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 6
   },
   "94Rb": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.8072312314944794,
     "quadrupole_moment": 0.163,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 7
   },
   "95Rb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.066196132131104,
     "quadrupole_moment": 0.21,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 6
   },
   "96Rb": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.58659857760739,
     "quadrupole_moment": 0.25,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 5
   },
   "97Rb": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.355462756515399,
     "quadrupole_moment": 0.581,
-    "atomic_number": 37
+    "atomic_number": 37,
+    "spin_multiplicity": 4
   },
   "79Sr": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.4087394603955996,
     "quadrupole_moment": 0.74,
-    "atomic_number": 38
+    "atomic_number": 38,
+    "spin_multiplicity": 4
   },
   "81Sr": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.2933814332608,
     "quadrupole_moment": 0.0,
-    "atomic_number": 38
+    "atomic_number": 38,
+    "spin_multiplicity": 2
   },
   "83Sr": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.8072079604306226,
     "quadrupole_moment": 0.823,
-    "atomic_number": 38
+    "atomic_number": 38,
+    "spin_multiplicity": 8
   },
   "85Sr": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.6947565612698998,
     "quadrupole_moment": 0.323,
-    "atomic_number": 38
+    "atomic_number": 38,
+    "spin_multiplicity": 10
   },
   "87Sr": {
-    "spin": 9,
     "natural_abundance": 7.000000000000001,
     "gyromagnetic_ratio": -1.8524646273607661,
     "quadrupole_moment": 0.335,
-    "atomic_number": 38
+    "atomic_number": 38,
+    "spin_multiplicity": 10
   },
   "89Sr": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.502734040636032,
     "quadrupole_moment": -0.274,
-    "atomic_number": 38
+    "atomic_number": 38,
+    "spin_multiplicity": 6
   },
   "91Sr": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.703886270226352,
     "quadrupole_moment": 0.044,
-    "atomic_number": 38
+    "atomic_number": 38,
+    "spin_multiplicity": 6
   },
   "93Sr": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.421545417020488,
     "quadrupole_moment": 0.265,
-    "atomic_number": 38
+    "atomic_number": 38,
+    "spin_multiplicity": 6
   },
   "95Sr": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -8.1866651280534,
     "quadrupole_moment": 0.0,
-    "atomic_number": 38
+    "atomic_number": 38,
+    "spin_multiplicity": 2
   },
   "97Sr": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -7.5966764121210595,
     "quadrupole_moment": 0.0,
-    "atomic_number": 38
+    "atomic_number": 38,
+    "spin_multiplicity": 2
   },
   "99Sr": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.3263312218633998,
     "quadrupole_moment": 0.84,
-    "atomic_number": 38
+    "atomic_number": 38,
+    "spin_multiplicity": 4
   },
   "86Y": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.1433889843649998,
     "quadrupole_moment": 0.0,
-    "atomic_number": 39
+    "atomic_number": 39,
+    "spin_multiplicity": 9
   },
   "89Y": {
-    "spin": 1,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": -2.094923395228136,
     "quadrupole_moment": 0.0,
-    "atomic_number": 39
+    "atomic_number": 39,
+    "spin_multiplicity": 2
   },
   "90Y": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -6.212413481716499,
     "quadrupole_moment": -0.155,
-    "atomic_number": 39
+    "atomic_number": 39,
+    "spin_multiplicity": 5
   },
   "91Y": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.5017350977906196,
     "quadrupole_moment": 0.0,
-    "atomic_number": 39
+    "atomic_number": 39,
+    "spin_multiplicity": 2
   },
   "91Zr": {
-    "spin": 5,
     "natural_abundance": 11.219999999999999,
     "gyromagnetic_ratio": -3.974785994127737,
     "quadrupole_moment": -0.206,
-    "atomic_number": 40
+    "atomic_number": 40,
+    "spin_multiplicity": 6
   },
   "90Nb": {
-    "spin": 16,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.726960626195638,
     "quadrupole_moment": 0.0,
-    "atomic_number": 41
+    "atomic_number": 41,
+    "spin_multiplicity": 17
   },
   "93Nb": {
-    "spin": 9,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 10.452269226702565,
     "quadrupole_moment": -0.32,
-    "atomic_number": 41
+    "atomic_number": 41,
+    "spin_multiplicity": 10
   },
   "95Nb": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.4022988933118,
     "quadrupole_moment": 0.0,
-    "atomic_number": 41
+    "atomic_number": 41,
+    "spin_multiplicity": 10
   },
   "96Nb": {
-    "spin": 12,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.3216706513336,
     "quadrupole_moment": 0.0,
-    "atomic_number": 41
+    "atomic_number": 41,
+    "spin_multiplicity": 13
   },
   "97Nb": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.422625808589398,
     "quadrupole_moment": 0.0,
-    "atomic_number": 41
+    "atomic_number": 41,
+    "spin_multiplicity": 10
   },
   "95Mo": {
-    "spin": 5,
     "natural_abundance": 15.920000000000002,
     "gyromagnetic_ratio": -2.787429892017288,
     "quadrupole_moment": -0.022,
-    "atomic_number": 42
+    "atomic_number": 42,
+    "spin_multiplicity": 6
   },
   "97Mo": {
-    "spin": 5,
     "natural_abundance": 9.55,
     "gyromagnetic_ratio": -2.8462763117459398,
     "quadrupole_moment": 0.255,
-    "atomic_number": 42
+    "atomic_number": 42,
+    "spin_multiplicity": 6
   },
   "99Mo": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.716944921825,
     "quadrupole_moment": 0.0,
-    "atomic_number": 42
+    "atomic_number": 42,
+    "spin_multiplicity": 2
   },
   "93Tc": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.603874136481332,
     "quadrupole_moment": 0.0,
-    "atomic_number": 43
+    "atomic_number": 43,
+    "spin_multiplicity": 10
   },
   "94Tc": {
-    "spin": 14,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.531824800546857,
     "quadrupole_moment": 0.0,
-    "atomic_number": 43
+    "atomic_number": 43,
+    "spin_multiplicity": 15
   },
   "95Tc": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.977127582088665,
     "quadrupole_moment": 0.0,
-    "atomic_number": 43
+    "atomic_number": 43,
+    "spin_multiplicity": 10
   },
   "96Tc": {
-    "spin": 14,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.488267124951999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 43
+    "atomic_number": 43,
+    "spin_multiplicity": 15
   },
   "99Tc": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.62936793988106,
     "quadrupole_moment": -0.129,
-    "atomic_number": 43
+    "atomic_number": 43,
+    "spin_multiplicity": 10
   },
   "95Ru": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.62522110810204,
     "quadrupole_moment": 0.0,
-    "atomic_number": 44
+    "atomic_number": 44,
+    "spin_multiplicity": 6
   },
   "97Ru": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.39959234852068,
     "quadrupole_moment": 0.0,
-    "atomic_number": 44
+    "atomic_number": 44,
+    "spin_multiplicity": 6
   },
   "99Ru": {
-    "spin": 5,
     "natural_abundance": 12.76,
     "gyromagnetic_ratio": -1.95443290394124,
     "quadrupole_moment": 0.079,
-    "atomic_number": 44
+    "atomic_number": 44,
+    "spin_multiplicity": 6
   },
   "101Ru": {
-    "spin": 5,
     "natural_abundance": 17.06,
     "gyromagnetic_ratio": -2.191648005230832,
     "quadrupole_moment": 0.457,
-    "atomic_number": 44
+    "atomic_number": 44,
+    "spin_multiplicity": 6
   },
   "103Ru": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.01634576388,
     "quadrupole_moment": 0.62,
-    "atomic_number": 44
+    "atomic_number": 44,
+    "spin_multiplicity": 4
   },
   "105Ru": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.626153222208,
     "quadrupole_moment": 0.0,
-    "atomic_number": 44
+    "atomic_number": 44,
+    "spin_multiplicity": 4
   },
   "105Rh": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.695938587415199,
     "quadrupole_moment": 0.0,
-    "atomic_number": 45
+    "atomic_number": 45,
+    "spin_multiplicity": 8
   },
   "106Rh": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 19.6281775649325,
     "quadrupole_moment": 0.0,
-    "atomic_number": 45
+    "atomic_number": 45,
+    "spin_multiplicity": 3
   },
   "101Pd": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.02151172435732,
     "quadrupole_moment": 0.0,
-    "atomic_number": 46
+    "atomic_number": 46,
+    "spin_multiplicity": 6
   },
   "105Pd": {
-    "spin": 5,
     "natural_abundance": 22.33,
     "gyromagnetic_ratio": -1.95748194123288,
     "quadrupole_moment": 0.66,
-    "atomic_number": 46
+    "atomic_number": 46,
+    "spin_multiplicity": 6
   },
   "101Ag": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.531629355587933,
     "quadrupole_moment": 0.0,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 10
   },
   "102Ag": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.012785770771999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 11
   },
   "103Ag": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.73514049545057,
     "quadrupole_moment": 0.0,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 8
   },
   "104Ag": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.97458857296858,
     "quadrupole_moment": 0.0,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 11
   },
   "105Ag": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.54586190686148,
     "quadrupole_moment": 0.0,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 2
   },
   "106Ag": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 21.724390702935,
     "quadrupole_moment": 0.0,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 3
   },
   "107Ag": {
-    "spin": 1,
     "natural_abundance": 51.839,
     "gyromagnetic_ratio": -1.731395826057774,
     "quadrupole_moment": 0.0,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 2
   },
   "108Ag": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 20.49257963711244,
     "quadrupole_moment": 0.0,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 3
   },
   "109Ag": {
-    "spin": 1,
     "natural_abundance": 48.161,
     "gyromagnetic_ratio": -1.9904572795419666,
     "quadrupole_moment": 0.0,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 2
   },
   "110Ag": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 20.78757399507861,
     "quadrupole_moment": 0.24,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 3
   },
   "111Ag": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.2257972228972,
     "quadrupole_moment": 0.0,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 2
   },
   "112Ag": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.20847792481588498,
     "quadrupole_moment": 0.0,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 5
   },
   "113Ag": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.4239846468537998,
     "quadrupole_moment": 0.0,
-    "atomic_number": 47
+    "atomic_number": 47,
+    "spin_multiplicity": 2
   },
   "103Cd": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.4697202062284003,
     "quadrupole_moment": -0.8,
-    "atomic_number": 48
+    "atomic_number": 48,
+    "spin_multiplicity": 6
   },
   "105Cd": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.2541532697094517,
     "quadrupole_moment": 0.43,
-    "atomic_number": 48
+    "atomic_number": 48,
+    "spin_multiplicity": 6
   },
   "107Cd": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.8753268510245569,
     "quadrupole_moment": 0.68,
-    "atomic_number": 48
+    "atomic_number": 48,
+    "spin_multiplicity": 6
   },
   "109Cd": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.5241336306387367,
     "quadrupole_moment": 0.68,
-    "atomic_number": 48
+    "atomic_number": 48,
+    "spin_multiplicity": 6
   },
   "111Cd": {
-    "spin": 1,
     "natural_abundance": 12.8,
     "gyromagnetic_ratio": -9.06914951589141,
     "quadrupole_moment": 0.0,
-    "atomic_number": 48
+    "atomic_number": 48,
+    "spin_multiplicity": 2
   },
   "113Cd": {
-    "spin": 1,
     "natural_abundance": 12.22,
     "gyromagnetic_ratio": -9.487093253605673,
     "quadrupole_moment": 0.0,
-    "atomic_number": 48
+    "atomic_number": 48,
+    "spin_multiplicity": 2
   },
   "115Cd": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -9.885373749826147,
     "quadrupole_moment": 0.0,
-    "atomic_number": 48
+    "atomic_number": 48,
+    "spin_multiplicity": 2
   },
   "105In": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.612937016698332,
     "quadrupole_moment": 0.83,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 10
   },
   "106In": {
-    "spin": 14,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.353238330607943,
     "quadrupole_moment": 0.97,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 15
   },
   "107In": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.460485152116332,
     "quadrupole_moment": 0.807,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 10
   },
   "108In": {
-    "spin": 14,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.9666639597035855,
     "quadrupole_moment": 1.005,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 15
   },
   "109In": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.3808714006124,
     "quadrupole_moment": 0.841,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 10
   },
   "110In": {
-    "spin": 14,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.132183126964042,
     "quadrupole_moment": 1.0,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 15
   },
   "111In": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.321584564386066,
     "quadrupole_moment": 0.804,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 10
   },
   "112In": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 21.495712906061996,
     "quadrupole_moment": 0.088,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 3
   },
   "113In": {
-    "spin": 9,
     "natural_abundance": 4.29,
     "gyromagnetic_ratio": 9.365456823193552,
     "quadrupole_moment": 0.799,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 10
   },
   "114In": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 21.4728451263747,
     "quadrupole_moment": 0.0,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 3
   },
   "115In": {
-    "spin": 9,
     "natural_abundance": 95.71,
     "gyromagnetic_ratio": 9.385614347510506,
     "quadrupole_moment": 0.86,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 10
   },
   "116In": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 21.23883151424133,
     "quadrupole_moment": 0.09,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 3
   },
   "117In": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.348687118089533,
     "quadrupole_moment": 0.829,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 10
   },
   "119In": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.341911479663665,
     "quadrupole_moment": 0.854,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 10
   },
   "121In": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.319890654779599,
     "quadrupole_moment": 0.814,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 10
   },
   "123In": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.301257649108466,
     "quadrupole_moment": 0.757,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 10
   },
   "124In": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 30.8181444252513,
     "quadrupole_moment": 0.61,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 3
   },
   "125In": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.319890654779599,
     "quadrupole_moment": 0.71,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 10
   },
   "126In": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.249847028729798,
     "quadrupole_moment": 0.494,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 7
   },
   "127In": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.353768846908933,
     "quadrupole_moment": 0.6,
-    "atomic_number": 49
+    "atomic_number": 49,
+    "spin_multiplicity": 10
   },
   "109Sn": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.2899112376795596,
     "quadrupole_moment": 0.31,
-    "atomic_number": 50
+    "atomic_number": 50,
+    "spin_multiplicity": 6
   },
   "111Sn": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.324153338083657,
     "quadrupole_moment": 0.18,
-    "atomic_number": 50
+    "atomic_number": 50,
+    "spin_multiplicity": 8
   },
   "113Sn": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -13.40204341540362,
     "quadrupole_moment": 0.0,
-    "atomic_number": 50
+    "atomic_number": 50,
+    "spin_multiplicity": 2
   },
   "115Sn": {
-    "spin": 1,
     "natural_abundance": 0.33999999999999997,
     "gyromagnetic_ratio": -14.007734673387906,
     "quadrupole_moment": 0.0,
-    "atomic_number": 50
+    "atomic_number": 50,
+    "spin_multiplicity": 2
   },
   "117Sn": {
-    "spin": 1,
     "natural_abundance": 7.68,
     "gyromagnetic_ratio": -15.261041452116526,
     "quadrupole_moment": 0.0,
-    "atomic_number": 50
+    "atomic_number": 50,
+    "spin_multiplicity": 2
   },
   "119Sn": {
-    "spin": 1,
     "natural_abundance": 8.59,
     "gyromagnetic_ratio": -15.965978873943694,
     "quadrupole_moment": 0.0,
-    "atomic_number": 50
+    "atomic_number": 50,
+    "spin_multiplicity": 2
   },
   "121Sn": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.5460303701773195,
     "quadrupole_moment": -0.02,
-    "atomic_number": 50
+    "atomic_number": 50,
+    "spin_multiplicity": 4
   },
   "123Sn": {
-    "spin": 11,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.8987186770667273,
     "quadrupole_moment": 0.03,
-    "atomic_number": 50
+    "atomic_number": 50,
+    "spin_multiplicity": 12
   },
   "125Sn": {
-    "spin": 11,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.8682283041503274,
     "quadrupole_moment": 0.09,
-    "atomic_number": 50
+    "atomic_number": 50,
+    "spin_multiplicity": 12
   },
   "115Sb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.5496690290744,
     "quadrupole_moment": -0.36,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 6
   },
   "116Sb": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.898446872335499,
     "quadrupole_moment": 0.0,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 7
   },
   "117Sb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.4581979103252,
     "quadrupole_moment": -0.3,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 6
   },
   "118Sb": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 18.827805275877,
     "quadrupole_moment": 0.0,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 3
   },
   "119Sb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.519178656158001,
     "quadrupole_moment": -0.37,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 6
   },
   "120Sb": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 17.836868156094,
     "quadrupole_moment": 0.0,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 3
   },
   "121Sb": {
-    "spin": 5,
     "natural_abundance": 57.21000000000001,
     "gyromagnetic_ratio": 10.255132026701975,
     "quadrupole_moment": -0.36,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 6
   },
   "122Sb": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -7.26052005071775,
     "quadrupole_moment": 0.84,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 5
   },
   "123Sb": {
-    "spin": 7,
     "natural_abundance": 42.79,
     "gyromagnetic_ratio": 5.5531680615883365,
     "quadrupole_moment": -0.49,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 8
   },
   "124Sb": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.0490372916399995,
     "quadrupole_moment": 1.9,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 7
   },
   "125Sb": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.727834340723714,
     "quadrupole_moment": 0.0,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 8
   },
   "126Sb": {
-    "spin": 16,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.219614916656,
     "quadrupole_moment": 0.0,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 17
   },
   "127Sb": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.640718989533999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 8
   },
   "128Sb": {
-    "spin": 16,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.248199641265125,
     "quadrupole_moment": 0.0,
-    "atomic_number": 51
+    "atomic_number": 51,
+    "spin_multiplicity": 17
   },
   "119Te": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.81129661455,
     "quadrupole_moment": 0.0,
-    "atomic_number": 52
+    "atomic_number": 52,
+    "spin_multiplicity": 2
   },
   "123Te": {
-    "spin": 1,
     "natural_abundance": 0.89,
     "gyromagnetic_ratio": -11.234906620960283,
     "quadrupole_moment": 0.0,
-    "atomic_number": 52
+    "atomic_number": 52,
+    "spin_multiplicity": 2
   },
   "125Te": {
-    "spin": 1,
     "natural_abundance": 7.07,
     "gyromagnetic_ratio": -13.545426375917229,
     "quadrupole_moment": 0.0,
-    "atomic_number": 52
+    "atomic_number": 52,
+    "spin_multiplicity": 2
   },
   "127Te": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.2268978003189996,
     "quadrupole_moment": 0.0,
-    "atomic_number": 52
+    "atomic_number": 52,
+    "spin_multiplicity": 4
   },
   "129Te": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.5673736312187994,
     "quadrupole_moment": 0.055,
-    "atomic_number": 52
+    "atomic_number": 52,
+    "spin_multiplicity": 4
   },
   "131Te": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.5368832583023995,
     "quadrupole_moment": 0.0,
-    "atomic_number": 52
+    "atomic_number": 52,
+    "spin_multiplicity": 4
   },
   "117I": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.452015604084,
     "quadrupole_moment": 0.0,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 6
   },
   "118I": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.6225932291,
     "quadrupole_moment": 0.0,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 5
   },
   "119I": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.842208145755999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 6
   },
   "120I": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.6878948358965,
     "quadrupole_moment": 0.0,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 5
   },
   "121I": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.012785770771999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 6
   },
   "122I": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.165237635353999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 3
   },
   "123I": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.59218708784152,
     "quadrupole_moment": 0.0,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 6
   },
   "124I": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.344878140586999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 5
   },
   "125I": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.60133419971644,
     "quadrupole_moment": -0.889,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 6
   },
   "126I": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.473021938493799,
     "quadrupole_moment": 0.0,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 5
   },
   "127I": {
-    "spin": 5,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 8.577765141452064,
     "quadrupole_moment": -0.79,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 6
   },
   "129I": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.708233386706028,
     "quadrupole_moment": -0.553,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 8
   },
   "131I": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.971757324054914,
     "quadrupole_moment": -0.4,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 8
   },
   "132I": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.8846419728652,
     "quadrupole_moment": 0.09,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 9
   },
   "133I": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.220036074945599,
     "quadrupole_moment": -0.27,
-    "atomic_number": 53
+    "atomic_number": 53,
+    "spin_multiplicity": 8
   },
   "117Xe": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.8105183437758319,
     "quadrupole_moment": 0.0,
-    "atomic_number": 54
+    "atomic_number": 54,
+    "spin_multiplicity": 6
   },
   "119Xe": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.829422374984,
     "quadrupole_moment": 0.0,
-    "atomic_number": 54
+    "atomic_number": 54,
+    "spin_multiplicity": 6
   },
   "121Xe": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.981874239566,
     "quadrupole_moment": 0.0,
-    "atomic_number": 54
+    "atomic_number": 54,
+    "spin_multiplicity": 6
   },
   "127Xe": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -7.68204945628698,
     "quadrupole_moment": 0.0,
-    "atomic_number": 54
+    "atomic_number": 54,
+    "spin_multiplicity": 2
   },
   "129Xe": {
-    "spin": 1,
     "natural_abundance": 26.400000000000002,
     "gyromagnetic_ratio": -11.860393753560539,
     "quadrupole_moment": 0.0,
-    "atomic_number": 54
+    "atomic_number": 54,
+    "spin_multiplicity": 2
   },
   "131Xe": {
-    "spin": 3,
     "natural_abundance": 21.232,
     "gyromagnetic_ratio": 3.5158545562748404,
     "quadrupole_moment": -0.12,
-    "atomic_number": 54
+    "atomic_number": 54,
+    "spin_multiplicity": 4
   },
   "133Xe": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.13347822169996,
     "quadrupole_moment": 0.145,
-    "atomic_number": 54
+    "atomic_number": 54,
+    "spin_multiplicity": 4
   },
   "135Xe": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.589055210359169,
     "quadrupole_moment": 0.0,
-    "atomic_number": 54
+    "atomic_number": 54,
+    "spin_multiplicity": 4
   },
   "137Xe": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.1134184198624686,
     "quadrupole_moment": -0.49,
-    "atomic_number": 54
+    "atomic_number": 54,
+    "spin_multiplicity": 8
   },
   "139Xe": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.5448455610975997,
     "quadrupole_moment": 0.4,
-    "atomic_number": 54
+    "atomic_number": 54,
+    "spin_multiplicity": 4
   },
   "141Xe": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.0304903729164,
     "quadrupole_moment": -0.58,
-    "atomic_number": 54
+    "atomic_number": 54,
+    "spin_multiplicity": 6
   },
   "143Xe": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.402252250425236,
     "quadrupole_moment": 0.94,
-    "atomic_number": 54
+    "atomic_number": 54,
+    "spin_multiplicity": 6
   },
   "118Cs": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 14.7725856779958,
     "quadrupole_moment": 1.4,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 5
   },
   "119Cs": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.248746451308,
     "quadrupole_moment": 2.8,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 10
   },
   "120Cs": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 14.7497178983085,
     "quadrupole_moment": 1.45,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 5
   },
   "121Cs": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.9129311909379996,
     "quadrupole_moment": 0.838,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 4
   },
   "122Cs": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.01609167743903,
     "quadrupole_moment": -0.19,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 3
   },
   "123Cs": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 20.9926217529414,
     "quadrupole_moment": 0.0,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 2
   },
   "124Cs": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.1300052431843,
     "quadrupole_moment": -0.74,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 3
   },
   "125Cs": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 21.480467719603798,
     "quadrupole_moment": 0.0,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 2
   },
   "126Cs": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.9227549390107,
     "quadrupole_moment": -0.68,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 3
   },
   "127Cs": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 22.2427270425138,
     "quadrupole_moment": 0.0,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 2
   },
   "128Cs": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.424405805143399,
     "quadrupole_moment": -0.57,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 3
   },
   "129Cs": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 22.7305730091762,
     "quadrupole_moment": 0.0,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 2
   },
   "130Cs": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.128986114485999,
     "quadrupole_moment": -0.059,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 3
   },
   "131Cs": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.80273912428052,
     "quadrupole_moment": -0.575,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 6
   },
   "132Cs": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.468701077530099,
     "quadrupole_moment": 0.508,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 5
   },
   "133Cs": {
-    "spin": 7,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 5.62335036639055,
     "quadrupole_moment": -0.00371,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 8
   },
   "134Cs": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.704939337489167,
     "quadrupole_moment": 0.389,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 9
   },
   "135Cs": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.950849639769383,
     "quadrupole_moment": 0.05,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 8
   },
   "136Cs": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.65748869463802,
     "quadrupole_moment": 0.225,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 11
   },
   "137Cs": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.18802118338338,
     "quadrupole_moment": 0.051,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 8
   },
   "138Cs": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.7786050867899996,
     "quadrupole_moment": 0.125,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 7
   },
   "139Cs": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.871574670186742,
     "quadrupole_moment": -0.075,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 8
   },
   "140Cs": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.020629407188313,
     "quadrupole_moment": -0.112,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 3
   },
   "141Cs": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.309680655013086,
     "quadrupole_moment": -0.36,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 8
   },
   "143Cs": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.421104072877999,
     "quadrupole_moment": 0.47,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 4
   },
   "144Cs": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -4.1619359030886,
     "quadrupole_moment": 0.3,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 3
   },
   "145Cs": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.9840753944096,
     "quadrupole_moment": 0.62,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 4
   },
   "146Cs": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.9256355129864997,
     "quadrupole_moment": 0.22,
-    "atomic_number": 55
+    "atomic_number": 55,
+    "spin_multiplicity": 3
   },
   "121Ba": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.0123646124824,
     "quadrupole_moment": 1.79,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 6
   },
   "123Ba": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.0733453583152,
     "quadrupole_moment": 1.49,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 6
   },
   "125Ba": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.6983980031013997,
     "quadrupole_moment": 0.0,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 2
   },
   "127Ba": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.3720667812379999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 2
   },
   "129Ba": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -6.0675842103636,
     "quadrupole_moment": 0.0,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 2
   },
   "131Ba": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.795314718475376,
     "quadrupole_moment": 0.0,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 2
   },
   "133Ba": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -11.764314014945025,
     "quadrupole_moment": 0.0,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 2
   },
   "135Ba": {
-    "spin": 3,
     "natural_abundance": 6.5920000000000005,
     "gyromagnetic_ratio": 4.258199092114494,
     "quadrupole_moment": 0.16,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 4
   },
   "137Ba": {
-    "spin": 3,
     "natural_abundance": 11.232000000000001,
     "gyromagnetic_ratio": 4.76343473479688,
     "quadrupole_moment": 0.245,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 4
   },
   "139Ba": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.1190809176897996,
     "quadrupole_moment": -0.573,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 8
   },
   "141Ba": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.7125426121378,
     "quadrupole_moment": 0.454,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 4
   },
   "143Ba": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.35072352019652,
     "quadrupole_moment": -0.879,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 6
   },
   "145Ba": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -0.8689756281173999,
     "quadrupole_moment": 1.224,
-    "atomic_number": 56
+    "atomic_number": 56,
+    "spin_multiplicity": 6
   },
   "137La": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.869396786406999,
     "quadrupole_moment": 0.24,
-    "atomic_number": 57
+    "atomic_number": 57,
+    "spin_multiplicity": 8
   },
   "138La": {
-    "spin": 10,
     "natural_abundance": 0.09,
     "gyromagnetic_ratio": 5.661522570974859,
     "quadrupole_moment": 0.45,
-    "atomic_number": 57
+    "atomic_number": 57,
+    "spin_multiplicity": 11
   },
   "139La": {
-    "spin": 7,
     "natural_abundance": 99.91,
     "gyromagnetic_ratio": 6.06114965273635,
     "quadrupole_moment": 0.2,
-    "atomic_number": 57
+    "atomic_number": 57,
+    "spin_multiplicity": 8
   },
   "140La": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.8548310190809998,
     "quadrupole_moment": 0.094,
-    "atomic_number": 57
+    "atomic_number": 57,
+    "spin_multiplicity": 7
   },
   "137Ce": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.878459666623999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 58
+    "atomic_number": 58,
+    "spin_multiplicity": 4
   },
   "139Ce": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.624373225654,
     "quadrupole_moment": 0.0,
-    "atomic_number": 58
+    "atomic_number": 58,
+    "spin_multiplicity": 4
   },
   "141Ce": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.373893319919714,
     "quadrupole_moment": 0.0,
-    "atomic_number": 58
+    "atomic_number": 58,
+    "spin_multiplicity": 8
   },
   "141Pr": {
-    "spin": 5,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 13.035854036677657,
     "quadrupole_moment": -0.0589,
-    "atomic_number": 59
+    "atomic_number": 59,
+    "spin_multiplicity": 6
   },
   "142Pr": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.8918434078047,
     "quadrupole_moment": 0.0297,
-    "atomic_number": 59
+    "atomic_number": 59,
+    "spin_multiplicity": 5
   },
   "135Nd": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.321249493044,
     "quadrupole_moment": 2.0,
-    "atomic_number": 60
+    "atomic_number": 60,
+    "spin_multiplicity": 10
   },
   "137Nd": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -9.6502030280406,
     "quadrupole_moment": 0.0,
-    "atomic_number": 60
+    "atomic_number": 60,
+    "spin_multiplicity": 2
   },
   "139Nd": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.6091280391958,
     "quadrupole_moment": 0.3,
-    "atomic_number": 60
+    "atomic_number": 60,
+    "spin_multiplicity": 4
   },
   "141Nd": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.147791294052199,
     "quadrupole_moment": 0.34,
-    "atomic_number": 60
+    "atomic_number": 60,
+    "spin_multiplicity": 4
   },
   "143Nd": {
-    "spin": 7,
     "natural_abundance": 12.2,
     "gyromagnetic_ratio": -2.3194462254261428,
     "quadrupole_moment": -0.63,
-    "atomic_number": 60
+    "atomic_number": 60,
+    "spin_multiplicity": 8
   },
   "145Nd": {
-    "spin": 7,
     "natural_abundance": 8.3,
     "gyromagnetic_ratio": -1.4286917595113142,
     "quadrupole_moment": -0.33,
-    "atomic_number": 60
+    "atomic_number": 60,
+    "spin_multiplicity": 8
   },
   "147Nd": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.7623435545679198,
     "quadrupole_moment": 0.9,
-    "atomic_number": 60
+    "atomic_number": 60,
+    "spin_multiplicity": 6
   },
   "149Nd": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.07021208936564,
     "quadrupole_moment": 1.3,
-    "atomic_number": 60
+    "atomic_number": 60,
+    "spin_multiplicity": 6
   },
   "143Pm": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.586341708231998,
     "quadrupole_moment": 0.0,
-    "atomic_number": 61
+    "atomic_number": 61,
+    "spin_multiplicity": 6
   },
   "144Pm": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.5764365114357997,
     "quadrupole_moment": 0.0,
-    "atomic_number": 61
+    "atomic_number": 61,
+    "spin_multiplicity": 11
   },
   "147Pm": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.618940151736571,
     "quadrupole_moment": 0.74,
-    "atomic_number": 61
+    "atomic_number": 61,
+    "spin_multiplicity": 8
   },
   "148Pm": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 15.854993916528,
     "quadrupole_moment": 0.2,
-    "atomic_number": 61
+    "atomic_number": 61,
+    "spin_multiplicity": 3
   },
   "149Pm": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.187016473151427,
     "quadrupole_moment": 0.0,
-    "atomic_number": 61
+    "atomic_number": 61,
+    "spin_multiplicity": 8
   },
   "151Pm": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.488267124952,
     "quadrupole_moment": 1.9,
-    "atomic_number": 61
+    "atomic_number": 61,
+    "spin_multiplicity": 6
   },
   "139Sm": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -8.079948822846,
     "quadrupole_moment": 0.0,
-    "atomic_number": 62
+    "atomic_number": 62,
+    "spin_multiplicity": 2
   },
   "141Sm": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -11.2357024196934,
     "quadrupole_moment": 0.0,
-    "atomic_number": 62
+    "atomic_number": 62,
+    "spin_multiplicity": 2
   },
   "143Sm": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.132546107593999,
     "quadrupole_moment": 0.41,
-    "atomic_number": 62
+    "atomic_number": 62,
+    "spin_multiplicity": 4
   },
   "145Sm": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.4174509955145713,
     "quadrupole_moment": -0.59,
-    "atomic_number": 62
+    "atomic_number": 62,
+    "spin_multiplicity": 8
   },
   "147Sm": {
-    "spin": 7,
     "natural_abundance": 14.99,
     "gyromagnetic_ratio": -1.77453970373448,
     "quadrupole_moment": -0.26,
-    "atomic_number": 62
+    "atomic_number": 62,
+    "spin_multiplicity": 8
   },
   "149Sm": {
-    "spin": 7,
     "natural_abundance": 13.819999999999999,
     "gyromagnetic_ratio": -1.4628845348532769,
     "quadrupole_moment": 0.075,
-    "atomic_number": 62
+    "atomic_number": 62,
+    "spin_multiplicity": 8
   },
   "151Sm": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.10680053686532,
     "quadrupole_moment": 0.67,
-    "atomic_number": 62
+    "atomic_number": 62,
+    "spin_multiplicity": 6
   },
   "153Sm": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -0.10976534249903999,
     "quadrupole_moment": 1.26,
-    "atomic_number": 62
+    "atomic_number": 62,
+    "spin_multiplicity": 4
   },
   "138Eu": {
-    "spin": 12,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.606247465219999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 13
   },
   "140Eu": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.404839757721499,
     "quadrupole_moment": 0.31,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 3
   },
   "141Eu": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.65333629699016,
     "quadrupole_moment": 0.85,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 6
   },
   "142Eu": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.7083031998976,
     "quadrupole_moment": 0.12,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 3
   },
   "143Eu": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.19911397219372,
     "quadrupole_moment": 0.51,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 6
   },
   "144Eu": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 14.4295689826863,
     "quadrupole_moment": 0.1,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 3
   },
   "145Eu": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 12.17480590551852,
     "quadrupole_moment": 0.29,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 6
   },
   "146Eu": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.715548837866875,
     "quadrupole_moment": -0.18,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 9
   },
   "147Eu": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.35461487406736,
     "quadrupole_moment": 0.55,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 6
   },
   "148Eu": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.5673736312188,
     "quadrupole_moment": 0.35,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 11
   },
   "149Eu": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.8698179446966,
     "quadrupole_moment": 0.75,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 6
   },
   "150Eu": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.12839649288056,
     "quadrupole_moment": 1.13,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 11
   },
   "151Eu": {
-    "spin": 5,
     "natural_abundance": 47.81,
     "gyromagnetic_ratio": 10.585342765386587,
     "quadrupole_moment": 0.903,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 6
   },
   "152Eu": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -4.932834164991579,
     "quadrupole_moment": 2.71,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 7
   },
   "153Eu": {
-    "spin": 5,
     "natural_abundance": 52.190000000000005,
     "gyromagnetic_ratio": 4.67417416808412,
     "quadrupole_moment": 2.412,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 6
   },
   "154Eu": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -5.0944331414485,
     "quadrupole_moment": 2.84,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 7
   },
   "155Eu": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.7564981749584,
     "quadrupole_moment": 2.34,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 6
   },
   "157Eu": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.57355593746,
     "quadrupole_moment": 2.6,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 6
   },
   "158Eu": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.976534249903999,
     "quadrupole_moment": 0.66,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 3
   },
   "159Eu": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.2076714624632,
     "quadrupole_moment": 0.0,
-    "atomic_number": 63
+    "atomic_number": 63,
+    "spin_multiplicity": 6
   },
   "147Gd": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.221441455337714,
     "quadrupole_moment": 0.0,
-    "atomic_number": 64
+    "atomic_number": 64,
+    "spin_multiplicity": 8
   },
   "149Gd": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.9165377261737142,
     "quadrupole_moment": 0.0,
-    "atomic_number": 64
+    "atomic_number": 64,
+    "spin_multiplicity": 8
   },
   "151Gd": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.6769705104019998,
     "quadrupole_moment": 0.0,
-    "atomic_number": 64
+    "atomic_number": 64,
+    "spin_multiplicity": 8
   },
   "153Gd": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.9310569513719997,
     "quadrupole_moment": 0.0,
-    "atomic_number": 64
+    "atomic_number": 64,
+    "spin_multiplicity": 4
   },
   "155Gd": {
-    "spin": 3,
     "natural_abundance": 14.799999999999999,
     "gyromagnetic_ratio": -1.3166759371065397,
     "quadrupole_moment": 1.3,
-    "atomic_number": 64
+    "atomic_number": 64,
+    "spin_multiplicity": 4
   },
   "157Gd": {
-    "spin": 3,
     "natural_abundance": 15.65,
     "gyromagnetic_ratio": -1.7267714528321199,
     "quadrupole_moment": 1.36,
-    "atomic_number": 64
+    "atomic_number": 64,
+    "spin_multiplicity": 4
   },
   "159Gd": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.235960680536,
     "quadrupole_moment": 0.0,
-    "atomic_number": 64
+    "atomic_number": 64,
+    "spin_multiplicity": 4
   },
   "149Tb": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 20.58100171857,
     "quadrupole_moment": 0.0,
-    "atomic_number": 65
+    "atomic_number": 65,
+    "spin_multiplicity": 2
   },
   "152Tb": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.430166953095,
     "quadrupole_moment": 0.5,
-    "atomic_number": 65
+    "atomic_number": 65,
+    "spin_multiplicity": 5
   },
   "153Tb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.671630520739999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 65
+    "atomic_number": 65,
+    "spin_multiplicity": 6
   },
   "155Tb": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.163457638799999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 65
+    "atomic_number": 65,
+    "spin_multiplicity": 4
   },
   "156Tb": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.5826188176769995,
     "quadrupole_moment": 2.3,
-    "atomic_number": 65
+    "atomic_number": 65,
+    "spin_multiplicity": 7
   },
   "157Tb": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.163457638799999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 65
+    "atomic_number": 65,
+    "spin_multiplicity": 4
   },
   "158Tb": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.4668396322526,
     "quadrupole_moment": 2.7,
-    "atomic_number": 65
+    "atomic_number": 65,
+    "spin_multiplicity": 7
   },
   "159Tb": {
-    "spin": 3,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 10.234601842271598,
     "quadrupole_moment": 1.432,
-    "atomic_number": 65
+    "atomic_number": 65,
+    "spin_multiplicity": 4
   },
   "160Tb": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.548147293363,
     "quadrupole_moment": 3.85,
-    "atomic_number": 65
+    "atomic_number": 65,
+    "spin_multiplicity": 7
   },
   "161Tb": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.17980340268,
     "quadrupole_moment": 1.2,
-    "atomic_number": 65
+    "atomic_number": 65,
+    "spin_multiplicity": 4
   },
   "147Dy": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -13.949345609253,
     "quadrupole_moment": 0.0,
-    "atomic_number": 66
+    "atomic_number": 66,
+    "spin_multiplicity": 2
   },
   "149Dy": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -0.2591681697894,
     "quadrupole_moment": -0.63,
-    "atomic_number": 66
+    "atomic_number": 66,
+    "spin_multiplicity": 8
   },
   "151Dy": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.058100171857,
     "quadrupole_moment": -0.3,
-    "atomic_number": 66
+    "atomic_number": 66,
+    "spin_multiplicity": 8
   },
   "153Dy": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.703105115758914,
     "quadrupole_moment": -0.02,
-    "atomic_number": 66
+    "atomic_number": 66,
+    "spin_multiplicity": 8
   },
   "155Dy": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.9564655954689998,
     "quadrupole_moment": 1.04,
-    "atomic_number": 66
+    "atomic_number": 66,
+    "spin_multiplicity": 4
   },
   "157Dy": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.5296003746393998,
     "quadrupole_moment": 1.3,
-    "atomic_number": 66
+    "atomic_number": 66,
+    "spin_multiplicity": 4
   },
   "159Dy": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.7989320020675996,
     "quadrupole_moment": 1.37,
-    "atomic_number": 66
+    "atomic_number": 66,
+    "spin_multiplicity": 4
   },
   "161Dy": {
-    "spin": 5,
     "natural_abundance": 18.91,
     "gyromagnetic_ratio": -1.464452611174692,
     "quadrupole_moment": 2.507,
-    "atomic_number": 66
+    "atomic_number": 66,
+    "spin_multiplicity": 6
   },
   "163Dy": {
-    "spin": 5,
     "natural_abundance": 24.9,
     "gyromagnetic_ratio": 2.050782482357064,
     "quadrupole_moment": 2.648,
-    "atomic_number": 66
+    "atomic_number": 66,
+    "spin_multiplicity": 6
   },
   "165Dy": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.1324995654662857,
     "quadrupole_moment": -3.49,
-    "atomic_number": 66
+    "atomic_number": 66,
+    "spin_multiplicity": 8
   },
   "152Ho": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.8875225468409997,
     "quadrupole_moment": 0.08,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 5
   },
   "153Ho": {
-    "spin": 11,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.438156343667453,
     "quadrupole_moment": -1.1,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 12
   },
   "154Ho": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.45066372315565,
     "quadrupole_moment": 0.19,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 5
   },
   "155Ho": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.671630520739999,
     "quadrupole_moment": 1.52,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 6
   },
   "156Ho": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.69788843875225,
     "quadrupole_moment": 2.34,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 9
   },
   "157Ho": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.473794441881427,
     "quadrupole_moment": 2.97,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 8
   },
   "158Ho": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.7474352947414,
     "quadrupole_moment": 4.1,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 11
   },
   "159Ho": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.32134257729943,
     "quadrupole_moment": 3.19,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 8
   },
   "160Ho": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.640718989534,
     "quadrupole_moment": 3.95,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 11
   },
   "161Ho": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.256006063907142,
     "quadrupole_moment": 3.22,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 8
   },
   "162Ho": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 17.684416291511997,
     "quadrupole_moment": 0.7,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 3
   },
   "163Ho": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.212448388312286,
     "quadrupole_moment": 3.6,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 8
   },
   "165Ho": {
-    "spin": 7,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 8.999015777897485,
     "quadrupole_moment": 3.58,
-    "atomic_number": 67
+    "atomic_number": 67,
+    "spin_multiplicity": 8
   },
   "153Er": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.0341434502798283,
     "quadrupole_moment": -0.42,
-    "atomic_number": 68
+    "atomic_number": 68,
+    "spin_multiplicity": 8
   },
   "155Er": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.4570042486479713,
     "quadrupole_moment": -0.27,
-    "atomic_number": 68
+    "atomic_number": 68,
+    "spin_multiplicity": 8
   },
   "157Er": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.0936722735927997,
     "quadrupole_moment": 0.92,
-    "atomic_number": 68
+    "atomic_number": 68,
+    "spin_multiplicity": 4
   },
   "159Er": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.5448455610975997,
     "quadrupole_moment": 1.17,
-    "atomic_number": 68
+    "atomic_number": 68,
+    "spin_multiplicity": 4
   },
   "161Er": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.8548310190809998,
     "quadrupole_moment": 1.361,
-    "atomic_number": 68
+    "atomic_number": 68,
+    "spin_multiplicity": 4
   },
   "163Er": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.6983137714434802,
     "quadrupole_moment": 2.55,
-    "atomic_number": 68
+    "atomic_number": 68,
+    "spin_multiplicity": 6
   },
   "165Er": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.96053097852452,
     "quadrupole_moment": 2.71,
-    "atomic_number": 68
+    "atomic_number": 68,
+    "spin_multiplicity": 6
   },
   "167Er": {
-    "spin": 7,
     "natural_abundance": 22.869,
     "gyromagnetic_ratio": -1.2279997692080098,
     "quadrupole_moment": 3.565,
-    "atomic_number": 68
+    "atomic_number": 68,
+    "spin_multiplicity": 8
   },
   "169Er": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.851271025972999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 68
+    "atomic_number": 68,
+    "spin_multiplicity": 2
   },
   "171Er": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.00931557519076,
     "quadrupole_moment": 2.86,
-    "atomic_number": 68
+    "atomic_number": 68,
+    "spin_multiplicity": 6
   },
   "156Tm": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.52451864582,
     "quadrupole_moment": -0.48,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 5
   },
   "157Tm": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.256708754103199,
     "quadrupole_moment": 0.0,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 2
   },
   "158Tm": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.1600744578111,
     "quadrupole_moment": 0.74,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 5
   },
   "159Tm": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.4277075374088,
     "quadrupole_moment": 1.93,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 6
   },
   "160Tm": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.1891245437395999,
     "quadrupole_moment": 0.582,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 3
   },
   "161Tm": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.226921071382857,
     "quadrupole_moment": 2.9,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 8
   },
   "162Tm": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.5183363395788,
     "quadrupole_moment": 0.69,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 3
   },
   "163Tm": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.2501052895724,
     "quadrupole_moment": 0.0,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 2
   },
   "164Tm": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 18.065545952967,
     "quadrupole_moment": 0.7,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 3
   },
   "165Tm": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.1190809176898,
     "quadrupole_moment": 0.0,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 2
   },
   "166Tm": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.3506392885386,
     "quadrupole_moment": 2.14,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 5
   },
   "167Tm": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.0033017322654,
     "quadrupole_moment": 0.0,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 2
   },
   "168Tm": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.5767762210019,
     "quadrupole_moment": 3.23,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 7
   },
   "169Tm": {
-    "spin": 1,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": -3.5307851837191198,
     "quadrupole_moment": 0.0,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 2
   },
   "170Tm": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.8873540835251599,
     "quadrupole_moment": 0.74,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 3
   },
   "171Tm": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.51096644132346,
     "quadrupole_moment": 0.0,
-    "atomic_number": 69
+    "atomic_number": 69,
+    "spin_multiplicity": 2
   },
   "155Yb": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.8294223749839997,
     "quadrupole_moment": -1.2,
-    "atomic_number": 70
+    "atomic_number": 70,
+    "spin_multiplicity": 8
   },
   "157Yb": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.3916677352556857,
     "quadrupole_moment": 0.0,
-    "atomic_number": 70
+    "atomic_number": 70,
+    "spin_multiplicity": 8
   },
   "159Yb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.11594764874024,
     "quadrupole_moment": -0.22,
-    "atomic_number": 70
+    "atomic_number": 70,
+    "spin_multiplicity": 6
   },
   "161Yb": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.6617253239438,
     "quadrupole_moment": 1.03,
-    "atomic_number": 70
+    "atomic_number": 70,
+    "spin_multiplicity": 4
   },
   "163Yb": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.9005665784555998,
     "quadrupole_moment": 1.24,
-    "atomic_number": 70
+    "atomic_number": 70,
+    "spin_multiplicity": 4
   },
   "165Yb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.4574398254039198,
     "quadrupole_moment": 2.48,
-    "atomic_number": 70
+    "atomic_number": 70,
+    "spin_multiplicity": 6
   },
   "167Yb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.89955023269172,
     "quadrupole_moment": 2.7,
-    "atomic_number": 70
+    "atomic_number": 70,
+    "spin_multiplicity": 6
   },
   "169Yb": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.3829562001367142,
     "quadrupole_moment": 3.54,
-    "atomic_number": 70
+    "atomic_number": 70,
+    "spin_multiplicity": 8
   },
   "171Yb": {
-    "spin": 1,
     "natural_abundance": 14.280000000000001,
     "gyromagnetic_ratio": 7.526091198819594,
     "quadrupole_moment": 0.0,
-    "atomic_number": 70
+    "atomic_number": 70,
+    "spin_multiplicity": 2
   },
   "173Yb": {
-    "spin": 5,
     "natural_abundance": 16.13,
     "gyromagnetic_ratio": -2.0730099642131194,
     "quadrupole_moment": 2.8,
-    "atomic_number": 70
+    "atomic_number": 70,
+    "spin_multiplicity": 6
   },
   "175Yb": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.263172592250857,
     "quadrupole_moment": 0.0,
-    "atomic_number": 70
+    "atomic_number": 70,
+    "spin_multiplicity": 8
   },
   "171Lu": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.421104072877999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 71
+    "atomic_number": 71,
+    "spin_multiplicity": 8
   },
   "172Lu": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.28770869136875,
     "quadrupole_moment": 0.0,
-    "atomic_number": 71
+    "atomic_number": 71,
+    "spin_multiplicity": 9
   },
   "173Lu": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.096248044598285,
     "quadrupole_moment": 0.0,
-    "atomic_number": 71
+    "atomic_number": 71,
+    "spin_multiplicity": 8
   },
   "174Lu": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 14.787830864454,
     "quadrupole_moment": 0.0,
-    "atomic_number": 71
+    "atomic_number": 71,
+    "spin_multiplicity": 3
   },
   "175Lu": {
-    "spin": 7,
     "natural_abundance": 97.41,
     "gyromagnetic_ratio": 4.862561115031877,
     "quadrupole_moment": 3.49,
-    "atomic_number": 71
+    "atomic_number": 71,
+    "spin_multiplicity": 8
   },
   "176Lu": {
-    "spin": 14,
     "natural_abundance": 2.59,
     "gyromagnetic_ratio": 3.451074637380531,
     "quadrupole_moment": 4.92,
-    "atomic_number": 71
+    "atomic_number": 71,
+    "spin_multiplicity": 15
   },
   "177Lu": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.876281782844257,
     "quadrupole_moment": 3.39,
-    "atomic_number": 71
+    "atomic_number": 71,
+    "spin_multiplicity": 8
   },
   "175Hf": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.64343110019396,
     "quadrupole_moment": 2.8,
-    "atomic_number": 72
+    "atomic_number": 72,
+    "spin_multiplicity": 6
   },
   "177Hf": {
-    "spin": 7,
     "natural_abundance": 18.6,
     "gyromagnetic_ratio": 1.728150779225957,
     "quadrupole_moment": 3.365,
-    "atomic_number": 72
+    "atomic_number": 72,
+    "spin_multiplicity": 8
   },
   "179Hf": {
-    "spin": 9,
     "natural_abundance": 13.62,
     "gyromagnetic_ratio": -1.0856266667844867,
     "quadrupole_moment": 3.79,
-    "atomic_number": 72
+    "atomic_number": 72,
+    "spin_multiplicity": 10
   },
   "173Ta": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.19251050766292,
     "quadrupole_moment": -1.9,
-    "atomic_number": 73
+    "atomic_number": 73,
+    "spin_multiplicity": 6
   },
   "175Ta": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.943796180016285,
     "quadrupole_moment": 3.65,
-    "atomic_number": 73
+    "atomic_number": 73,
+    "spin_multiplicity": 8
   },
   "177Ta": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.900238504421428,
     "quadrupole_moment": 0.0,
-    "atomic_number": 73
+    "atomic_number": 73,
+    "spin_multiplicity": 8
   },
   "178Ta": {
-    "spin": 14,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.983700778247714,
     "quadrupole_moment": 0.66,
-    "atomic_number": 73
+    "atomic_number": 73,
+    "spin_multiplicity": 15
   },
   "181Ta": {
-    "spin": 7,
     "natural_abundance": 99.988,
     "gyromagnetic_ratio": 5.162673499880442,
     "quadrupole_moment": 3.28,
-    "atomic_number": 73
+    "atomic_number": 73,
+    "spin_multiplicity": 8
   },
   "182Ta": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.673410517293999,
     "quadrupole_moment": 2.9,
-    "atomic_number": 73
+    "atomic_number": 73,
+    "spin_multiplicity": 7
   },
   "183Ta": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.139805720193142,
     "quadrupole_moment": 0.0,
-    "atomic_number": 73
+    "atomic_number": 73,
+    "spin_multiplicity": 8
   },
   "183W": {
-    "spin": 1,
     "natural_abundance": 14.31,
     "gyromagnetic_ratio": 1.795650628134337,
     "quadrupole_moment": 0.0,
-    "atomic_number": 74
+    "atomic_number": 74,
+    "spin_multiplicity": 2
   },
   "187W": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.1557535968473998,
     "quadrupole_moment": 0.0,
-    "atomic_number": 74
+    "atomic_number": 74,
+    "spin_multiplicity": 4
   },
   "179Re": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.537304416591999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 75
+    "atomic_number": 75,
+    "spin_multiplicity": 6
   },
   "181Re": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.7264289603316,
     "quadrupole_moment": 0.0,
-    "atomic_number": 75
+    "atomic_number": 75,
+    "spin_multiplicity": 6
   },
   "182Re": {
-    "spin": 14,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.0925949672348567,
     "quadrupole_moment": 4.1,
-    "atomic_number": 75
+    "atomic_number": 75,
+    "spin_multiplicity": 15
   },
   "183Re": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.65935013991552,
     "quadrupole_moment": 2.3,
-    "atomic_number": 75
+    "atomic_number": 75,
+    "spin_multiplicity": 6
   },
   "184Re": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.428386956540999,
     "quadrupole_moment": 2.8,
-    "atomic_number": 75
+    "atomic_number": 75,
+    "spin_multiplicity": 7
   },
   "185Re": {
-    "spin": 5,
     "natural_abundance": 37.4,
     "gyromagnetic_ratio": 9.717586752185843,
     "quadrupole_moment": 2.18,
-    "atomic_number": 75
+    "atomic_number": 75,
+    "spin_multiplicity": 6
   },
   "186Re": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 13.2556896254049,
     "quadrupole_moment": 0.618,
-    "atomic_number": 75
+    "atomic_number": 75,
+    "spin_multiplicity": 3
   },
   "187Re": {
-    "spin": 5,
     "natural_abundance": 62.6,
     "gyromagnetic_ratio": 9.816985367893308,
     "quadrupole_moment": 2.07,
-    "atomic_number": 75
+    "atomic_number": 75,
+    "spin_multiplicity": 6
   },
   "188Re": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 13.6291966936308,
     "quadrupole_moment": 0.572,
-    "atomic_number": 75
+    "atomic_number": 75,
+    "spin_multiplicity": 3
   },
   "183Os": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.3449642275345333,
     "quadrupole_moment": 3.12,
-    "atomic_number": 76
+    "atomic_number": 76,
+    "spin_multiplicity": 10
   },
   "187Os": {
-    "spin": 1,
     "natural_abundance": 1.6,
     "gyromagnetic_ratio": 0.985630117925036,
     "quadrupole_moment": 0.0,
-    "atomic_number": 76
+    "atomic_number": 76,
+    "spin_multiplicity": 2
   },
   "189Os": {
-    "spin": 3,
     "natural_abundance": 16.21,
     "gyromagnetic_ratio": 3.3536005449730997,
     "quadrupole_moment": 0.856,
-    "atomic_number": 76
+    "atomic_number": 76,
+    "spin_multiplicity": 4
   },
   "193Os": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.81129661455,
     "quadrupole_moment": 0.47,
-    "atomic_number": 76
+    "atomic_number": 76,
+    "spin_multiplicity": 4
   },
   "184Ir": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.06106497749072,
     "quadrupole_moment": 2.1,
-    "atomic_number": 77
+    "atomic_number": 77,
+    "spin_multiplicity": 11
   },
   "185Ir": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.9427421447221995,
     "quadrupole_moment": -2.06,
-    "atomic_number": 77
+    "atomic_number": 77,
+    "spin_multiplicity": 6
   },
   "186Ir": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.9151323457816,
     "quadrupole_moment": -2.54,
-    "atomic_number": 77
+    "atomic_number": 77,
+    "spin_multiplicity": 11
   },
   "188Ir": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.3020231551881998,
     "quadrupole_moment": 0.543,
-    "atomic_number": 77
+    "atomic_number": 77,
+    "spin_multiplicity": 3
   },
   "189Ir": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.660624746522,
     "quadrupole_moment": 1.04,
-    "atomic_number": 77
+    "atomic_number": 77,
+    "spin_multiplicity": 4
   },
   "190Ir": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.076225932291,
     "quadrupole_moment": 2.85,
-    "atomic_number": 77
+    "atomic_number": 77,
+    "spin_multiplicity": 9
   },
   "191Ir": {
-    "spin": 3,
     "natural_abundance": 37.3,
     "gyromagnetic_ratio": 0.7658165330835799,
     "quadrupole_moment": 0.816,
-    "atomic_number": 77
+    "atomic_number": 77,
+    "spin_multiplicity": 4
   },
   "192Ir": {
-    "spin": 8,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.6664673431970995,
     "quadrupole_moment": 2.28,
-    "atomic_number": 77
+    "atomic_number": 77,
+    "spin_multiplicity": 9
   },
   "193Ir": {
-    "spin": 3,
     "natural_abundance": 62.7,
     "gyromagnetic_ratio": 0.8318790077357799,
     "quadrupole_moment": 0.751,
-    "atomic_number": 77
+    "atomic_number": 77,
+    "spin_multiplicity": 4
   },
   "194Ir": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.972811359349,
     "quadrupole_moment": 0.339,
-    "atomic_number": 77
+    "atomic_number": 77,
+    "spin_multiplicity": 3
   },
   "183Pt": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.9427421447221995,
     "quadrupole_moment": 0.0,
-    "atomic_number": 78
+    "atomic_number": 78,
+    "spin_multiplicity": 2
   },
   "185Pt": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.4059449733673333,
     "quadrupole_moment": 4.2,
-    "atomic_number": 78
+    "atomic_number": 78,
+    "spin_multiplicity": 10
   },
   "187Pt": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.0174463413018,
     "quadrupole_moment": -1.13,
-    "atomic_number": 78
+    "atomic_number": 78,
+    "spin_multiplicity": 4
   },
   "189Pt": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.2054703076195996,
     "quadrupole_moment": -0.65,
-    "atomic_number": 78
+    "atomic_number": 78,
+    "spin_multiplicity": 4
   },
   "191Pt": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.5408644096999997,
     "quadrupole_moment": -0.64,
-    "atomic_number": 78
+    "atomic_number": 78,
+    "spin_multiplicity": 4
   },
   "195Pt": {
-    "spin": 1,
     "natural_abundance": 33.832,
     "gyromagnetic_ratio": 9.292246050002063,
     "quadrupole_moment": 0.0,
-    "atomic_number": 78
+    "atomic_number": 78,
+    "spin_multiplicity": 2
   },
   "197Pt": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.7750450936819995,
     "quadrupole_moment": 0.0,
-    "atomic_number": 78
+    "atomic_number": 78,
+    "spin_multiplicity": 2
   },
   "185Au": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.616410922858799,
     "quadrupole_moment": 0.0,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 6
   },
   "186Au": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.201489156222,
     "quadrupole_moment": 0.0,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 7
   },
   "187Au": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.0951940093042,
     "quadrupole_moment": 0.0,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 2
   },
   "188Au": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -0.5107137463497,
     "quadrupole_moment": 0.0,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 3
   },
   "189Au": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.470141364518,
     "quadrupole_moment": 0.0,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 2
   },
   "190Au": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -0.4954685598915,
     "quadrupole_moment": 0.0,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 3
   },
   "191Au": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.6961968482577999,
     "quadrupole_moment": -1.3,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 4
   },
   "192Au": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -0.06860333906189998,
     "quadrupole_moment": 0.0,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 3
   },
   "193Au": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.711442034716,
     "quadrupole_moment": 0.0,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 4
   },
   "194Au": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.5716944921824999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 3
   },
   "195Au": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.7571775940905999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 4
   },
   "196Au": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.2509517805532298,
     "quadrupole_moment": 0.81,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 5
   },
   "197Au": {
-    "spin": 3,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 0.7406416485122722,
     "quadrupole_moment": 0.547,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 4
   },
   "198Au": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.26162341107397,
     "quadrupole_moment": 0.69,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 5
   },
   "199Au": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.3796893744671,
     "quadrupole_moment": 0.55,
-    "atomic_number": 79
+    "atomic_number": 79,
+    "spin_multiplicity": 4
   },
   "181Hg": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.730834052953219,
     "quadrupole_moment": 0.0,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 2
   },
   "183Hg": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.9884777040968,
     "quadrupole_moment": 0.0,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 2
   },
   "185Hg": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.7445547207656,
     "quadrupole_moment": 0.0,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 2
   },
   "187Hg": {
-    "spin": 13,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.2243057432585231,
     "quadrupole_moment": 0.45,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 14
   },
   "189Hg": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.09274015948684,
     "quadrupole_moment": -0.76,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 4
   },
   "191Hg": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.1405084103891996,
     "quadrupole_moment": -0.8,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 4
   },
   "193Hg": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -3.1891405551908574,
     "quadrupole_moment": -0.72,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 4
   },
   "195Hg": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.254885812935198,
     "quadrupole_moment": 0.0,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 2
   },
   "197Hg": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.03992106128135,
     "quadrupole_moment": 0.0,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 2
   },
   "199Hg": {
-    "spin": 1,
     "natural_abundance": 16.869999999999997,
     "gyromagnetic_ratio": 7.712318773999735,
     "quadrupole_moment": 0.0,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 2
   },
   "201Hg": {
-    "spin": 3,
     "natural_abundance": 13.18,
     "gyromagnetic_ratio": -2.8469150850585385,
     "quadrupole_moment": 0.385,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 4
   },
   "203Hg": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.588480208737778,
     "quadrupole_moment": 0.343,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 6
   },
   "205Hg": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.162357061378199,
     "quadrupole_moment": 0.0,
-    "atomic_number": 80
+    "atomic_number": 80,
+    "spin_multiplicity": 2
   },
   "190Tl": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.9528241536375,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 5
   },
   "191Tl": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 24.2093560956216,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 2
   },
   "192Tl": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.76225932291,
     "quadrupole_moment": -0.337,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 5
   },
   "193Tl": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 24.25814069228784,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 2
   },
   "194Tl": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.533581526037,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 5
   },
   "195Tl": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 24.087394603956,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 2
   },
   "196Tl": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.2667907630185,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 5
   },
   "197Tl": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 24.087394603956,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 2
   },
   "199Tl": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 24.39229833312,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 2
   },
   "200Tl": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 76.378384155582,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 5
   },
   "201Tl": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 24.470048784056818,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 2
   },
   "202Tl": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.2667907630185,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 5
   },
   "203Tl": {
-    "spin": 1,
     "natural_abundance": 29.524,
     "gyromagnetic_ratio": 24.731623711432377,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 2
   },
   "204Tl": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.34301669530949996,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 5
   },
   "205Tl": {
-    "spin": 1,
     "natural_abundance": 70.476,
     "gyromagnetic_ratio": 24.974887187997393,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 2
   },
   "207Tl": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 28.599969795583196,
     "quadrupole_moment": 0.0,
-    "atomic_number": 81
+    "atomic_number": 81,
+    "spin_multiplicity": 2
   },
   "197Pb": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -5.464382999500819,
     "quadrupole_moment": -0.08,
-    "atomic_number": 82
+    "atomic_number": 82,
+    "spin_multiplicity": 4
   },
   "199Pb": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -5.45879309779948,
     "quadrupole_moment": 0.08,
-    "atomic_number": 82
+    "atomic_number": 82,
+    "spin_multiplicity": 4
   },
   "201Pb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.059014883044492,
     "quadrupole_moment": -0.009,
-    "atomic_number": 82
+    "atomic_number": 82,
+    "spin_multiplicity": 6
   },
   "203Pb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.092859196981696,
     "quadrupole_moment": 0.095,
-    "atomic_number": 82
+    "atomic_number": 82,
+    "spin_multiplicity": 6
   },
   "205Pb": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.169999840460188,
     "quadrupole_moment": 0.226,
-    "atomic_number": 82
+    "atomic_number": 82,
+    "spin_multiplicity": 6
   },
   "207Pb": {
-    "spin": 1,
     "natural_abundance": 22.1,
     "gyromagnetic_ratio": 9.03403832695953,
     "quadrupole_moment": 0.0,
-    "atomic_number": 82
+    "atomic_number": 82,
+    "spin_multiplicity": 2
   },
   "209Pb": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.495975805128633,
     "quadrupole_moment": -0.27,
-    "atomic_number": 82
+    "atomic_number": 82,
+    "spin_multiplicity": 10
   },
   "211Pb": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.37774091459726,
     "quadrupole_moment": 0.087,
-    "atomic_number": 82
+    "atomic_number": 82,
+    "spin_multiplicity": 10
   },
   "199Bi": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.820143964683634,
     "quadrupole_moment": 0.0,
-    "atomic_number": 83
+    "atomic_number": 83,
+    "spin_multiplicity": 10
   },
   "203Bi": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.825862381876,
     "quadrupole_moment": -0.68,
-    "atomic_number": 83
+    "atomic_number": 83,
+    "spin_multiplicity": 10
   },
   "204Bi": {
-    "spin": 12,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.437449836758,
     "quadrupole_moment": -0.43,
-    "atomic_number": 83
+    "atomic_number": 83,
+    "spin_multiplicity": 13
   },
   "205Bi": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.0466639629013335,
     "quadrupole_moment": 0.0,
-    "atomic_number": 83
+    "atomic_number": 83,
+    "spin_multiplicity": 10
   },
   "206Bi": {
-    "spin": 12,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.843988142309999,
     "quadrupole_moment": -0.2,
-    "atomic_number": 83
+    "atomic_number": 83,
+    "spin_multiplicity": 13
   },
   "207Bi": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.912845103990467,
     "quadrupole_moment": -0.58,
-    "atomic_number": 83
+    "atomic_number": 83,
+    "spin_multiplicity": 10
   },
   "209Bi": {
-    "spin": 9,
     "natural_abundance": 100.0,
     "gyromagnetic_ratio": 6.962984828341879,
     "quadrupole_moment": -0.37,
-    "atomic_number": 83
+    "atomic_number": 83,
+    "spin_multiplicity": 10
   },
   "210Bi": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -0.339281624627241,
     "quadrupole_moment": 0.136,
-    "atomic_number": 83
+    "atomic_number": 83,
+    "spin_multiplicity": 3
   },
   "201Po": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.7604793263559997,
     "quadrupole_moment": 0.0,
-    "atomic_number": 84
+    "atomic_number": 84,
+    "spin_multiplicity": 4
   },
   "203Po": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.26238567039688,
     "quadrupole_moment": 0.0,
-    "atomic_number": 84
+    "atomic_number": 84,
+    "spin_multiplicity": 6
   },
   "205Po": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.3172683416464,
     "quadrupole_moment": 0.17,
-    "atomic_number": 84
+    "atomic_number": 84,
+    "spin_multiplicity": 6
   },
   "207Po": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.41788657227052,
     "quadrupole_moment": 0.28,
-    "atomic_number": 84
+    "atomic_number": 84,
+    "spin_multiplicity": 6
   },
   "209Po": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 11.738793572814,
     "quadrupole_moment": 0.0,
-    "atomic_number": 84
+    "atomic_number": 84,
+    "spin_multiplicity": 2
   },
   "205Rn": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.44532790789528,
     "quadrupole_moment": 0.062,
-    "atomic_number": 86
+    "atomic_number": 86,
+    "spin_multiplicity": 6
   },
   "207Rn": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.48801442997824,
     "quadrupole_moment": 0.22,
-    "atomic_number": 86
+    "atomic_number": 86,
+    "spin_multiplicity": 6
   },
   "209Rn": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.5575629706005483,
     "quadrupole_moment": 0.311,
-    "atomic_number": 86
+    "atomic_number": 86,
+    "spin_multiplicity": 6
   },
   "211Rn": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.162357061378199,
     "quadrupole_moment": 0.0,
-    "atomic_number": 86
+    "atomic_number": 86,
+    "spin_multiplicity": 2
   },
   "219Rn": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.34767448290488,
     "quadrupole_moment": 1.15,
-    "atomic_number": 86
+    "atomic_number": 86,
+    "spin_multiplicity": 6
   },
   "221Rn": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -0.04355767559485714,
     "quadrupole_moment": -0.38,
-    "atomic_number": 86
+    "atomic_number": 86,
+    "spin_multiplicity": 8
   },
   "223Rn": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.690037813080457,
     "quadrupole_moment": 0.8,
-    "atomic_number": 86
+    "atomic_number": 86,
+    "spin_multiplicity": 8
   },
   "225Rn": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -1.5158071107010282,
     "quadrupole_moment": 0.85,
-    "atomic_number": 86
+    "atomic_number": 86,
+    "spin_multiplicity": 8
   },
   "207Fr": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.589308369155333,
     "quadrupole_moment": -0.16,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 10
   },
   "208Fr": {
-    "spin": 14,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.172473976889285,
     "quadrupole_moment": 0.004,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 15
   },
   "209Fr": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.690942945543333,
     "quadrupole_moment": -0.24,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 10
   },
   "210Fr": {
-    "spin": 12,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.58990170134,
     "quadrupole_moment": 0.19,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 13
   },
   "211Fr": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.775638425866666,
     "quadrupole_moment": -0.19,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 10
   },
   "212Fr": {
-    "spin": 10,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.0432761436884,
     "quadrupole_moment": -0.1,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 11
   },
   "213Fr": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.809516617995999,
     "quadrupole_moment": -0.14,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 10
   },
   "220Fr": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -5.107137463497,
     "quadrupole_moment": 0.47,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 3
   },
   "221Fr": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.8174789207912,
     "quadrupole_moment": -1.0,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 6
   },
   "222Fr": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.4011168671665,
     "quadrupole_moment": 0.51,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 5
   },
   "223Fr": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.945622718697999,
     "quadrupole_moment": 1.17,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 4
   },
   "224Fr": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.04903729164,
     "quadrupole_moment": 0.517,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 3
   },
   "225Fr": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.437449836758,
     "quadrupole_moment": 1.32,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 4
   },
   "226Fr": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 0.5427286379119199,
     "quadrupole_moment": -1.35,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 3
   },
   "227Fr": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 22.8677796873,
     "quadrupole_moment": 0.0,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 2
   },
   "228Fr": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.896585427058,
     "quadrupole_moment": 2.38,
-    "atomic_number": 87
+    "atomic_number": 87,
+    "spin_multiplicity": 5
   },
   "209Ra": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.6404662945602397,
     "quadrupole_moment": 0.38,
-    "atomic_number": 88
+    "atomic_number": 88,
+    "spin_multiplicity": 6
   },
   "211Ra": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.67705474205992,
     "quadrupole_moment": 0.46,
-    "atomic_number": 88
+    "atomic_number": 88,
+    "spin_multiplicity": 6
   },
   "213Ra": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.349872854814059,
     "quadrupole_moment": 0.0,
-    "atomic_number": 88
+    "atomic_number": 88,
+    "spin_multiplicity": 2
   },
   "221Ra": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -0.548521808766036,
     "quadrupole_moment": 1.978,
-    "atomic_number": 88
+    "atomic_number": 88,
+    "spin_multiplicity": 6
   },
   "223Ra": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.3746076456476999,
     "quadrupole_moment": 1.254,
-    "atomic_number": 88
+    "atomic_number": 88,
+    "spin_multiplicity": 4
   },
   "225Ra": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -11.186917823027159,
     "quadrupole_moment": 0.0,
-    "atomic_number": 88
+    "atomic_number": 88,
+    "spin_multiplicity": 2
   },
   "227Ra": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.0520020972737196,
     "quadrupole_moment": 1.5,
-    "atomic_number": 88
+    "atomic_number": 88,
+    "spin_multiplicity": 4
   },
   "229Ra": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.5321412390490998,
     "quadrupole_moment": 2.96,
-    "atomic_number": 88
+    "atomic_number": 88,
+    "spin_multiplicity": 6
   },
   "217Ac": {
-    "spin": 9,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 6.479204244735,
     "quadrupole_moment": 0.0,
-    "atomic_number": 89
+    "atomic_number": 89,
+    "spin_multiplicity": 10
   },
   "227Ac": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 5.58990170134,
     "quadrupole_moment": 1.7,
-    "atomic_number": 89
+    "atomic_number": 89,
+    "spin_multiplicity": 4
   },
   "229Th": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.4025571541544,
     "quadrupole_moment": 4.3,
-    "atomic_number": 90
+    "atomic_number": 90,
+    "spin_multiplicity": 6
   },
   "228Pa": {
-    "spin": 6,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.842208145755999,
     "quadrupole_moment": 0.0,
-    "atomic_number": 91
+    "atomic_number": 91,
+    "spin_multiplicity": 7
   },
   "230Pa": {
-    "spin": 4,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 7.6225932291,
     "quadrupole_moment": 0.0,
-    "atomic_number": 91
+    "atomic_number": 91,
+    "spin_multiplicity": 5
   },
   "231Pa": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 10.214274926993998,
     "quadrupole_moment": -1.72,
-    "atomic_number": 91
+    "atomic_number": 91,
+    "spin_multiplicity": 4
   },
   "233Pa": {
-    "spin": 3,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 17.227060697766,
     "quadrupole_moment": -3.0,
-    "atomic_number": 91
+    "atomic_number": 91,
+    "spin_multiplicity": 4
   },
   "233U": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 1.829422374984,
     "quadrupole_moment": 3.663,
-    "atomic_number": 92
+    "atomic_number": 92,
+    "spin_multiplicity": 6
   },
   "235U": {
-    "spin": 7,
     "natural_abundance": 0.7204,
     "gyromagnetic_ratio": -0.8275958363022856,
     "quadrupole_moment": 4.55,
-    "atomic_number": 92
+    "atomic_number": 92,
+    "spin_multiplicity": 8
   },
   "237Np": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 9.5739770957496,
     "quadrupole_moment": 3.886,
-    "atomic_number": 93
+    "atomic_number": 93,
+    "spin_multiplicity": 6
   },
   "239Pu": {
-    "spin": 1,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 3.0947728510146,
     "quadrupole_moment": 0.0,
-    "atomic_number": 94
+    "atomic_number": 94,
+    "spin_multiplicity": 2
   },
   "241Pu": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": -2.08249247019012,
     "quadrupole_moment": 5.6,
-    "atomic_number": 94
+    "atomic_number": 94,
+    "spin_multiplicity": 6
   },
   "241Am": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.9089500395404,
     "quadrupole_moment": 4.3,
-    "atomic_number": 95
+    "atomic_number": 95,
+    "spin_multiplicity": 6
   },
   "242Am": {
-    "spin": 2,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 2.95680391356789,
     "quadrupole_moment": -2.4,
-    "atomic_number": 95
+    "atomic_number": 95,
+    "spin_multiplicity": 3
   },
   "243Am": {
-    "spin": 5,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.6650270562092,
     "quadrupole_moment": 4.3,
-    "atomic_number": 95
+    "atomic_number": 95,
+    "spin_multiplicity": 6
   },
   "249Bk": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 4.355767559485714,
     "quadrupole_moment": 0.0,
-    "atomic_number": 97
+    "atomic_number": 97,
+    "spin_multiplicity": 8
   },
   "253Es": {
-    "spin": 7,
     "natural_abundance": 0.0,
     "gyromagnetic_ratio": 8.929323496945713,
     "quadrupole_moment": 6.7,
-    "atomic_number": 99
+    "atomic_number": 99,
+    "spin_multiplicity": 8
   }
 }


### PR DESCRIPTION
Previously integer values of `2*I`, where `I` is the spin of the nucleus, were stored under the keyword "spin". This was slightly ambiguous, so the stored isotope data has been updated to spin_multiplicity, `2*I + 1`,  which are all integer values and unambiguous.