### PR TITLE
djs/test binaries build

### DIFF
--- a/.github/workflows/continuous-integration-pip.yml
+++ b/.github/workflows/continuous-integration-pip.yml
@@ -34,7 +34,7 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=8 --max-line-length=88 --statistics --exclude="examples/* *.npy docs/* *.pyx *.pxd"
 
-  testing_unix:
+  test_matrix:
     needs: [code_lint]
     strategy:
       matrix:
@@ -53,11 +53,9 @@ jobs:
 
       - name: Install linux system dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get install --yes libopenblas-dev libfftw3-dev
-
-      - name: check gcc version on linux system
-        if: startsWith(matrix.os, 'ubuntu')
-        run: gcc -v
+        run: |
+          sudo apt-get install --yes libopenblas-dev libfftw3-dev
+          gcc -v
 
       - name: Install macos system dependencies
         if: startsWith(matrix.os, 'mac')
@@ -65,13 +63,17 @@ jobs:
 
       - name: Install windows system dependencies
         if: startsWith(matrix.os, 'windows')
-        run: C:\Miniconda\Scripts\conda install -c conda-forge openblas fftw
+        run: |
+          C:\Miniconda\Scripts\conda install -c conda-forge openblas fftw
+          set LIBPATH=C:\Miniconda\Library\lib
+          set INCLUDE=C:\Miniconda\Library\include;C:\Miniconda\Library\include\openblas
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pytest cython setuptools pytest-cov sympy sybil
           pip install -r requirements.txt
+
       - name: Build and install package from source
         run: python setup.py develop
 

--- a/.github/workflows/continuous-integration-pip.yml
+++ b/.github/workflows/continuous-integration-pip.yml
@@ -65,8 +65,7 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         run: |
           C:\Miniconda\Scripts\conda install -c conda-forge openblas fftw
-          set LIBPATH=C:\Miniconda\Library\lib
-          set INCLUDE="C:\Miniconda\Library\include;C:\Miniconda\Library\include\openblas"
+          set CL="/IC:\Miniconda\Library\include /IC:\Miniconda\Library\include\openblas /LIBPATH:C:\Miniconda\Library\lib"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/continuous-integration-pip.yml
+++ b/.github/workflows/continuous-integration-pip.yml
@@ -38,7 +38,7 @@ jobs:
     needs: [code_lint]
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["windows-latest"]
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
 
@@ -65,8 +65,8 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         run: |
           C:\Miniconda\Scripts\conda install -c conda-forge openblas fftw
-          set LIBPATH=C:\Miniconda\Library\lib
-          set INCLUDE=C:\Miniconda\Library\include;C:\Miniconda\Library\include\openblas
+          set LIBPATH=C:\\Miniconda\\Library\\lib
+          set INCLUDE=C:\\Miniconda\\Library\\include;C:\\Miniconda\\Library\\include\\openblas
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/continuous-integration-pip.yml
+++ b/.github/workflows/continuous-integration-pip.yml
@@ -65,7 +65,6 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         run: |
           C:\Miniconda\Scripts\conda install -c conda-forge openblas fftw
-          set CL="/IC:\Miniconda\Library\include /IC:\Miniconda\Library\include\openblas /LIBPATH:C:\Miniconda\Library\lib"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/continuous-integration-pip.yml
+++ b/.github/workflows/continuous-integration-pip.yml
@@ -34,12 +34,12 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=8 --max-line-length=88 --statistics --exclude="examples/* *.npy docs/* *.pyx *.pxd"
 
-  test_matrix:
+  testing_unix:
     needs: [code_lint]
     strategy:
       matrix:
-        os: ["windows-latest"]
-        python-version: ["3.11"]
+        os: ["ubuntu-latest", "macos-latest"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -60,11 +60,6 @@ jobs:
       - name: Install macos system dependencies
         if: startsWith(matrix.os, 'mac')
         run: brew install openblas fftw
-
-      - name: Install windows system dependencies
-        if: startsWith(matrix.os, 'windows')
-        run: |
-          C:\Miniconda\Scripts\conda install -c conda-forge openblas fftw
 
       - name: Install dependencies
         run: |
@@ -121,38 +116,38 @@ jobs:
   #     - name: Upload coverage
   #       uses: codecov/codecov-action@v3.1.3
 
-  # testing_windows:
-  #   needs: [code_lint]
-  #   strategy:
-  #     matrix:
-  #       python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
-  #   runs-on: "windows-latest"
+  testing_windows:
+    needs: [code_lint]
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+    runs-on: "windows-latest"
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #     - name: Setup Miniconda
-  #       uses: conda-incubator/setup-miniconda@v2
-  #       env:
-  #         ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
-  #       with:
-  #         auto-update-conda: true
-  #         auto-activate-base: false
-  #         miniconda-version: "latest"
-  #         python-version: ${{ matrix.python-version }}
-  #         environment-file: environment-dev.yml
-  #         activate-environment: mrsimulator-dev
-  #     - run: |
-  #         conda --version
-  #         which python
-  #     - name: Build and install package from source
-  #       shell: pwsh
-  #       run: |
-  #         conda --version
-  #         which python
-  #         python setup.py develop
-  #     - name: Test with pytest
-  #       shell: pwsh
-  #       run: pytest --cov=./ --cov-report=xml
-  #     - name: Upload coverage
-  #       uses: codecov/codecov-action@v3.1.3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+        with:
+          auto-update-conda: true
+          auto-activate-base: false
+          miniconda-version: "latest"
+          python-version: ${{ matrix.python-version }}
+          environment-file: environment-dev.yml
+          activate-environment: mrsimulator-dev
+      - run: |
+          conda --version
+          which python
+      - name: Build and install package from source
+        shell: pwsh
+        run: |
+          conda --version
+          which python
+          python setup.py develop
+      - name: Test with pytest
+        shell: pwsh
+        run: pytest --cov=./ --cov-report=xml
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3.1.3

--- a/.github/workflows/continuous-integration-pip.yml
+++ b/.github/workflows/continuous-integration-pip.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-latest"]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.11"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -65,8 +65,8 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         run: |
           C:\Miniconda\Scripts\conda install -c conda-forge openblas fftw
-          set LIBPATH=C:\\Miniconda\\Library\\lib
-          set INCLUDE=C:\\Miniconda\\Library\\include;C:\\Miniconda\\Library\\include\\openblas
+          set LIBPATH=C:\Miniconda\Library\lib
+          set INCLUDE="C:\Miniconda\Library\include;C:\Miniconda\Library\include\openblas"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/continuous-integration-pip.yml
+++ b/.github/workflows/continuous-integration-pip.yml
@@ -33,11 +33,12 @@ jobs:
           flake8 . --count --select=B,C,E,F,W,T,N8 --ignore=E402 --max-line-length=88 --show-source --statistics --exclude="examples/* *.npy docs/* *.pyx *.pxd"
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=8 --max-line-length=88 --statistics --exclude="examples/* *.npy docs/* *.pyx *.pxd"
+
   testing_unix:
     needs: [code_lint]
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
 
@@ -61,6 +62,10 @@ jobs:
       - name: Install macos system dependencies
         if: startsWith(matrix.os, 'mac')
         run: brew install openblas fftw
+
+      - name: Install windows system dependencies
+        if: startsWith(matrix.os, 'windows')
+        run: C:\Miniconda\Scripts\conda install -c conda-forge openblas fftw
 
       - name: Install dependencies
         run: |
@@ -116,38 +121,38 @@ jobs:
   #     - name: Upload coverage
   #       uses: codecov/codecov-action@v3.1.3
 
-  testing_windows:
-    needs: [code_lint]
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
-    runs-on: "windows-latest"
+  # testing_windows:
+  #   needs: [code_lint]
+  #   strategy:
+  #     matrix:
+  #       python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+  #   runs-on: "windows-latest"
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
-        with:
-          auto-update-conda: true
-          auto-activate-base: false
-          miniconda-version: "latest"
-          python-version: ${{ matrix.python-version }}
-          environment-file: environment-dev.yml
-          activate-environment: mrsimulator-dev
-      - run: |
-          conda --version
-          which python
-      - name: Build and install package from source
-        shell: pwsh
-        run: |
-          conda --version
-          which python
-          python setup.py develop
-      - name: Test with pytest
-        shell: pwsh
-        run: pytest --cov=./ --cov-report=xml
-      - name: Upload coverage
-        uses: codecov/codecov-action@v3.1.3
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #     - name: Setup Miniconda
+  #       uses: conda-incubator/setup-miniconda@v2
+  #       env:
+  #         ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+  #       with:
+  #         auto-update-conda: true
+  #         auto-activate-base: false
+  #         miniconda-version: "latest"
+  #         python-version: ${{ matrix.python-version }}
+  #         environment-file: environment-dev.yml
+  #         activate-environment: mrsimulator-dev
+  #     - run: |
+  #         conda --version
+  #         which python
+  #     - name: Build and install package from source
+  #       shell: pwsh
+  #       run: |
+  #         conda --version
+  #         which python
+  #         python setup.py develop
+  #     - name: Test with pytest
+  #       shell: pwsh
+  #       run: pytest --cov=./ --cov-report=xml
+  #     - name: Upload coverage
+  #       uses: codecov/codecov-action@v3.1.3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -135,7 +135,7 @@ jobs:
             name: linux 64-bit x86_64
             cibw:
               build: "cp3*manylinux_x86_64"
-              manylinux_image: manylinux2010
+              manylinux_image: manylinux2014
 
           # - os: ubuntu-latest
           #   name: linux 32-bit i686

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -89,6 +89,7 @@ jobs:
       CIBW_BEFORE_ALL_LINUX: "yum -y install openblas-devel fftw-devel"
 
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
+      CIBW_SKIP: "${{ matrix.cibw.skip || 'cp36*' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
       CIBW_MANYLINUX_I686_IMAGE: "${{ matrix.cibw.manylinux_image }}"
       CIBW_MANYLINUX_AARCH64_IMAGE: "${{ matrix.cibw.manylinux_image }}"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -180,7 +180,7 @@ jobs:
       - name: customize mac-arm-64
         if: contains(matrix.os, 'macos') && matrix.cibw.arch
         run: |
-          sudo xcode-select -switch /Applications/Xcode_12.4.app
+          sudo xcode-select -switch /Applications/Xcode_12.6.app
           echo 'SDKROOT=/Applications/Xcode_12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk' >> "$GITHUB_ENV"
           echo 'MACOSX_DEPLOYMENT_TARGET=11.1' >> "$GITHUB_ENV"
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -125,11 +125,11 @@ jobs:
             cibw:
               build: "cp3*"
 
-          - os: macos-latest
-            name: mac 64-bit arm64
-            cibw:
-              arch: arm64
-              build: "cp3*"
+          # - os: macos-latest
+          #   name: mac 64-bit arm64
+          #   cibw:
+          #     arch: arm64
+          #     build: "cp3*"
 
           - os: ubuntu-latest
             name: linux 64-bit x86_64

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -180,8 +180,8 @@ jobs:
       - name: customize mac-arm-64
         if: contains(matrix.os, 'macos') && matrix.cibw.arch
         run: |
-          sudo xcode-select -switch /Applications/Xcode_12.6.app
-          echo 'SDKROOT=/Applications/Xcode_12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk' >> "$GITHUB_ENV"
+          sudo xcode-select -switch /Applications/Xcode_13.1.app
+          echo 'SDKROOT=/Applications/Xcode_13.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk' >> "$GITHUB_ENV"
           echo 'MACOSX_DEPLOYMENT_TARGET=11.1' >> "$GITHUB_ENV"
 
       - name: Set up QEMU

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "numpy>=1.20",
+    "numpy",
     "cython>=0.29"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -68,17 +68,6 @@ class Setup:
         self.extra_compile_args = ["/DUSE_OPENBLAS"]
 
         print(sys.version)
-        miniconda = join("C:", "Miniconda")
-        self.include_dirs += self.check_valid_path(
-            [
-                join(miniconda, "Library", "include", "fftw"),
-                join(miniconda, "Library", "include", "openblas"),
-                join(miniconda, "Library", "include"),
-                join(miniconda, "include"),
-            ]
-        )
-        self.library_dirs += self.check_valid_path([join(miniconda, "Library", "lib")])
-
         loc = dirname(sys.executable)
         print("executable location", loc)
         if "conda" not in loc:

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,19 @@ class Setup:
         self.extra_compile_args = ["/DUSE_OPENBLAS"]
 
         print(sys.version)
+        miniconda = join("C:", "Miniconda")
+        self.include_dirs += self.check_valid_path(
+            [
+                join(miniconda, "Library", "include", "fftw"),
+                join(miniconda, "Library", "include", "openblas"),
+                join(miniconda, "Library", "include"),
+                join(miniconda, "include"),
+            ]
+        )
+        self.library_dirs += self.check_valid_path([join(miniconda, "Library", "lib")])
+
         loc = dirname(sys.executable)
+        print("executable location", loc)
         if "conda" not in loc:
             return
 


### PR DESCRIPTION
Update the wheel and CI yml files to run builds on GitHub action.
- GutHub doesn't host the m1 Mac runner yet. It is likely going to be in Q4 2023 (https://github.com/github/roadmap/issues/528). Will add the build when available.
- Remove support for py36 builds.
- `manylinux2010` reached the end of its lifetime. Switching to `manylinux2014`