### PR TITLE
djs/simplify custom isotope

### DIFF
--- a/src/mrsimulator/method/__init__.py
+++ b/src/mrsimulator/method/__init__.py
@@ -134,7 +134,7 @@ class Method(Parseable):
         >>> print(method.affine_matrix)
         [[1, -1], [0, 1]]
     """
-    channels: List[Union[str, Isotope]]
+    channels: List[Union[str, dict, Isotope]]
     spectral_dimensions: List[SpectralDimension] = [SpectralDimension()]
     affine_matrix: List = None
     simulation: Union[cp.CSDM, np.ndarray] = None
@@ -175,7 +175,7 @@ class Method(Parseable):
 
     @validator("channels", always=True)
     def validate_channels(cls, v, *, values, **kwargs):
-        return [Isotope(symbol=_) for _ in v]
+        return [Isotope.parse(_) for _ in v]
 
     def __init__(self, **kwargs):
         Method.check(kwargs)

--- a/src/mrsimulator/method/__init__.py
+++ b/src/mrsimulator/method/__init__.py
@@ -134,7 +134,7 @@ class Method(Parseable):
         >>> print(method.affine_matrix)
         [[1, -1], [0, 1]]
     """
-    channels: List[str]
+    channels: List[Union[str, Isotope]]
     spectral_dimensions: List[SpectralDimension] = [SpectralDimension()]
     affine_matrix: List = None
     simulation: Union[cp.CSDM, np.ndarray] = None

--- a/src/mrsimulator/simulator/__init__.py
+++ b/src/mrsimulator/simulator/__init__.py
@@ -220,21 +220,17 @@ class Simulator(Parseable):
         Example
         -------
 
-        >>> sim.get_isotopes()
-        [Isotope(symbol='13C'), Isotope(symbol='1H'), Isotope(symbol='27Al')]
+        >>> len(sim.get_isotopes())
+        3
         >>> sim.get_isotopes(symbol=True)
         ['13C', '1H', '27Al']
 
-        >>> sim.get_isotopes(spin_I=0.5)
-        [Isotope(symbol='13C'), Isotope(symbol='1H')]
         >>> sim.get_isotopes(spin_I=0.5, symbol=True)
         ['13C', '1H']
 
         >>> sim.get_isotopes(spin_I=1.5)
         []
 
-        >>> sim.get_isotopes(spin_I=2.5)
-        [Isotope(symbol='27Al')]
         >>> sim.get_isotopes(spin_I=2.5, symbol=True)
         ['27Al']
         """

--- a/src/mrsimulator/spin_system/__init__.py
+++ b/src/mrsimulator/spin_system/__init__.py
@@ -15,7 +15,7 @@ from pydantic import Field
 from pydantic import validator
 
 from .coupling import Coupling
-from .isotope import ISOTOPE_DATA
+from .isotope import get_all_isotope_data
 from .site import Site
 from .split_spinsystems import build_new_systems
 from .zeemanstate import ZeemanState
@@ -478,11 +478,11 @@ def allowed_isotopes(spin_I: float = None) -> list:
         allowed isotopes is returned instead.
     """
     if spin_I is None:
-        return list(ISOTOPE_DATA.keys())
+        return list(get_all_isotope_data().keys())
     return list(
         {
             isotope
-            for isotope, data in ISOTOPE_DATA.items()
+            for isotope, data in get_all_isotope_data().items()
             if data["spin_multiplicity"] == int(2 * spin_I + 1)  # 2S+1
         }
     )

--- a/src/mrsimulator/spin_system/__init__.py
+++ b/src/mrsimulator/spin_system/__init__.py
@@ -252,21 +252,17 @@ class SpinSystem(Parseable):
         Example
         -------
 
-        >>> spin_systems.get_isotopes() # three spin systems
-        [Isotope(symbol='13C'), Isotope(symbol='1H'), Isotope(symbol='27Al')]
+        >>> len(spin_systems.get_isotopes()) # three spin systems
+        3
         >>> spin_systems.get_isotopes(symbol=True) # three spin systems
         ['13C', '1H', '27Al']
 
-        >>> spin_systems.get_isotopes(spin_I=0.5) # isotopes with I=0.5
-        [Isotope(symbol='13C'), Isotope(symbol='1H')]
         >>> spin_systems.get_isotopes(spin_I=0.5, symbol=True) # isotopes with I=0.5
         ['13C', '1H']
 
         >>> spin_systems.get_isotopes(spin_I=1.5) # isotopes with I=1.5
         []
 
-        >>> spin_systems.get_isotopes(spin_I=2.5) # isotopes with I=2.5
-        [Isotope(symbol='27Al')]
         >>> spin_systems.get_isotopes(spin_I=2.5, symbol=True) # isotopes with I=2.5
         ['27Al']
         """

--- a/src/mrsimulator/spin_system/isotope.py
+++ b/src/mrsimulator/spin_system/isotope.py
@@ -144,14 +144,14 @@ def format_isotope_string(isotope_string: str) -> str:
     result = match(r"(\d+)\s*(\w+)", isotope_string)
 
     if result is None:
-        raise Exception(f"Could not parse isotope string {isotope_string}")
+        raise Exception(f"Could not parse isotope string `{isotope_string}`")
 
     isotope = result.group(2)
     A = result.group(1)
 
     formatted_string = f"{A}{isotope}"
     if formatted_string not in ISOTOPE_DATA:
-        raise Exception(f"Could not parse isotope string {isotope_string}")
+        raise Exception(f"Could not parse isotope string `{isotope_string}`")
 
     return formatted_string
 
@@ -174,3 +174,10 @@ def get_isotope_dict(isotope_string: str) -> dict:
 def get_all_isotope_symbols() -> list:
     """Returns a list of all currently valid isotope symbols"""
     return list(ISOTOPE_DATA.keys()) + list(Isotope.custom_isotope_data.keys())
+
+
+def get_all_isotope_data() -> dict:
+    """Returns an intersected dictionary of the real and custom isotope data"""
+    iso_dict = ISOTOPE_DATA.copy()
+    iso_dict.update(Isotope.custom_isotope_data)
+    return iso_dict

--- a/src/mrsimulator/spin_system/site.py
+++ b/src/mrsimulator/spin_system/site.py
@@ -1,6 +1,7 @@
 """Base Site class."""
 from typing import ClassVar
 from typing import Dict
+from typing import Union
 
 from mrsimulator.utils.parseable import Parseable
 from pydantic import validator
@@ -149,7 +150,7 @@ class Site(Parseable):
     ... )
     """
 
-    isotope: str = "1H"
+    isotope: Union[str, Isotope] = "1H"
     isotropic_chemical_shift: float = 0.0
     shielding_symmetric: SymmetricTensor = None
     shielding_antisymmetric: AntisymmetricTensor = None

--- a/src/mrsimulator/spin_system/site.py
+++ b/src/mrsimulator/spin_system/site.py
@@ -150,7 +150,7 @@ class Site(Parseable):
     ... )
     """
 
-    isotope: Union[str, Isotope] = "1H"
+    isotope: Union[str, dict, Isotope] = "1H"
     isotropic_chemical_shift: float = 0.0
     shielding_symmetric: SymmetricTensor = None
     shielding_antisymmetric: AntisymmetricTensor = None
@@ -201,7 +201,7 @@ class Site(Parseable):
 
     @validator("isotope", always=True)
     def validate_isotope(cls, v, *, values, **kwargs):
-        return Isotope(symbol=v)
+        return Isotope.parse(v)
 
     @classmethod
     def parse_dict_with_units(cls, py_dict: dict):

--- a/src/mrsimulator/spin_system/tests/test_isotope.py
+++ b/src/mrsimulator/spin_system/tests/test_isotope.py
@@ -32,10 +32,44 @@ def test_isotope():
     assert nitrogen.spin == 1
     assert nitrogen.larmor_freq(B0=18.79) == -57.830093199115574
 
-    with pytest.raises(Exception, match="Could not parse isotope string"):
-        Isotope(symbol="x")
+    error = "is immutable and does not support item assignment"
+    with pytest.raises(Exception, match=error):
+        nitrogen.spin_multiplicity = 4
 
-    with pytest.raises(Exception, match="Could not parse isotope string"):
-        Isotope(symbol="14F")
+    error = "spin_multiplicity for 1H cannot be assigned."
+    with pytest.raises(Exception, match=error):
+        _ = Isotope(symbol="1H", spin_multiplicity=5)
 
     assert nitrogen.json() == "14N"
+
+
+def test_custom_isotope():
+    custom = Isotope(
+        symbol="custom",
+        spin_multiplicity=4,
+        gyromagnetic_ratio=-12.3,
+        quadrupole_moment=0.1,
+        natural_abundance=50,
+    )
+
+    assert isinstance(custom, Isotope)
+    assert custom.symbol == "custom"
+    assert custom.spin == 1.5
+    assert custom.spin_multiplicity == 4
+    assert custom.gyromagnetic_ratio == -12.3
+    assert custom.quadrupole_moment == 0.1
+    assert custom.natural_abundance == 50
+
+    # Instantiating Isotope from just string
+    custom_from_string = Isotope(symbol="custom")
+
+    assert custom == custom_from_string
+
+    assert custom.json() == {
+        "symbol": "custom",
+        "spin_multiplicity": 4,
+        "gyromagnetic_ratio": -12.3,
+        "quadrupole_moment": 0.1,
+        "natural_abundance": 50,
+        "atomic_number": 0,
+    }

--- a/src/mrsimulator/spin_system/tests/test_isotope.py
+++ b/src/mrsimulator/spin_system/tests/test_isotope.py
@@ -36,7 +36,7 @@ def test_isotope():
     with pytest.raises(Exception, match=error):
         nitrogen.spin_multiplicity = 4
 
-    error = "spin_multiplicity for 1H cannot be assigned."
+    error = "spin_multiplicity for `1H` cannot be assigned."
     with pytest.raises(Exception, match=error):
         _ = Isotope(symbol="1H", spin_multiplicity=5)
 
@@ -73,9 +73,9 @@ def test_custom_isotope():
     assert custom.json() == {
         "symbol": "custom",
         "spin_multiplicity": 4,
-        "gyromagnetic_ratio": -12.3,
-        "quadrupole_moment": 0.1,
-        "natural_abundance": 50,
+        "gyromagnetic_ratio": "-12.3 MHz/T",
+        "quadrupole_moment": "0.1 barn",
+        "natural_abundance": "50.0 %",
         "atomic_number": 0,
     }
 

--- a/src/mrsimulator/spin_system/tests/test_isotope.py
+++ b/src/mrsimulator/spin_system/tests/test_isotope.py
@@ -44,13 +44,15 @@ def test_isotope():
 
 
 def test_custom_isotope():
-    custom = Isotope(
+    Isotope.register(
         symbol="custom",
         spin_multiplicity=4,
         gyromagnetic_ratio=-12.3,
         quadrupole_moment=0.1,
         natural_abundance=50,
     )
+
+    custom = Isotope(symbol="custom")
 
     assert isinstance(custom, Isotope)
     assert custom.symbol == "custom"
@@ -59,11 +61,6 @@ def test_custom_isotope():
     assert custom.gyromagnetic_ratio == -12.3
     assert custom.quadrupole_moment == 0.1
     assert custom.natural_abundance == 50
-
-    # Instantiating Isotope from just string
-    custom_from_string = Isotope(symbol="custom")
-
-    assert custom == custom_from_string
 
     assert custom.json() == {
         "symbol": "custom",

--- a/src/mrsimulator/spin_system/tests/test_isotope.py
+++ b/src/mrsimulator/spin_system/tests/test_isotope.py
@@ -40,6 +40,14 @@ def test_isotope():
     with pytest.raises(Exception, match=error):
         _ = Isotope(symbol="1H", spin_multiplicity=5)
 
+    # error = "Could not parse isotope string `x`"
+    # with pytest.raises(Exception, match=error):
+    #     _ = Isotope(symbol="x")
+
+    # error = "Could not parse isotope string `20H`"
+    # with pytest.raises(Exception, match=error):
+    #     _ = Isotope(symbol="20H")
+
     assert nitrogen.json() == "14N"
 
 
@@ -70,3 +78,30 @@ def test_custom_isotope():
         "natural_abundance": 50,
         "atomic_number": 0,
     }
+
+    # Attempt to register a custom isotope under a real symbol
+    error = "`1H` is an immutable registry symbol"
+    with pytest.raises(Exception, match=error):
+        _ = Isotope.register(symbol="1H", spin_multiplicity=5)
+
+
+def test_isotope_parse():
+    test_iso = Isotope(symbol="1H")
+    test_iso_dict = test_iso.json()
+
+    # Parse from string
+    iso = Isotope.parse("1H")
+    assert iso == test_iso
+
+    # Parse from dict
+    iso = Isotope.parse(test_iso_dict)
+    assert iso == test_iso
+
+    # Parse from Isotope object
+    iso = Isotope.parse(test_iso)
+    assert iso == test_iso
+
+    # # Check for error when unparsable type passed
+    # error = ""
+    # with pytest.raises(ValueError, match=error):
+    #     _ = Isotope.parse(123)


### PR DESCRIPTION
## Create custom isotopes by registering isotopes.

```py
from mrsimulator.spin_system.isotope import Isotope

Isotope.register('1A', copy_from='2H')
Isotope.register('wA', gyromagnetic_ratio=4.5, spin_multiplicity=4)

# now use the custom isotopes in the script as usual

from mrsimulator import Site
siteA = Site(isotope="1A", isotropic_chemical_shift=10)
siteA.isotope.json()
# {'symbol': '1A',
#  'spin_multiplicity': 3,
#  'gyromagnetic_ratio': '6.5359028463694875 MHz/T',
#  'quadrupole_moment': '0.00286 barn',
#  'natural_abundance': '0.015 %'}
```