### PR TITLE
Convert spectral dimension to periodic dimension

### DIFF
--- a/src/mrsimulator/method/spectral_dimension.py
+++ b/src/mrsimulator/method/spectral_dimension.py
@@ -199,6 +199,7 @@ class SpectralDimension(Parseable):
             label=label,
             description=description,
             complex_fft=True,
+            period=f"{self.spectral_width} Hz",
             reciprocal=reciprocal,
         )
         if self.origin_offset is not None:

--- a/src/mrsimulator/signal_processor/tests/test_apodization.py
+++ b/src/mrsimulator/signal_processor/tests/test_apodization.py
@@ -252,6 +252,8 @@ def test_2D_area():
     data = np.zeros((256, 128), dtype=float)
     data[128, 64] = 1.0
     csdm_obj = cp.as_csdm(data)
+    csdm_obj.x[0].period = "256"
+    csdm_obj.x[1].period = "128"
 
     # test00
     PS = [


### PR DESCRIPTION
Considering all simulations are done in the frequency domain, the signal is assumed periodic. 

The PR adds a period to the  csdm object dimension when serializing.