### PR TITLE
djs/Undo forced py3.7.16 for mac

### DIFF
--- a/.github/workflows/continuous-integration-pip.yml
+++ b/.github/workflows/continuous-integration-pip.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: "macos-latest"
     strategy:
       matrix:
-        python-version: [3.7.16, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Wait until the issue is fixed for GitHub action and then revert the py3.7 constraints.