### PR TITLE
Update version requirements

### DIFF
--- a/docs/installation/requirements.rst
+++ b/docs/installation/requirements.rst
@@ -21,11 +21,11 @@ following operating systems:
 - `lmfit>=1.0.3 <https://lmfit.github.io/lmfit-py/>`_ for least-squares fitting
 - `pandas>=1.1.3 <https://pandas.pydata.org/docs/>`_
 - `csdmpy>=0.4.1 <https://csdmpy.readthedocs.io/en/stable/>`_
-- `pydantic==1.10 <https://pydantic-docs.helpmanual.io>`_
+- `pydantic<2 <https://pydantic-docs.helpmanual.io>`_
 - `nmrglue>=0.9 <https://nmrglue.readthedocs.io/>`_
 - monty>=2.0.4
 - typing-extensions>=3.7
-- numexpr>=2.7.1
+- numexpr==2.8.4
 - psutil>=5.4.8
 - joblib>=1.0.0
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,12 +2,12 @@ numpy>=1.20
 matplotlib>=3.3.3
 csdmpy>=0.6.dev2
 astropy>=3.0
-pydantic==1.10
+pydantic<2
 monty>=2.0.4
 typing-extensions>=3.7
 lmfit>=1.0.2
 pandas>=1.1.3
-numexpr>=2.7.1
+numexpr==2.8.4
 psutil>=5.4.8
 joblib>=1.0.0
 cython>=0.29.11

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -16,7 +16,7 @@ dependencies:
       - monty>=2.0.4
       - csdmpy>=0.6.dev2
       - astropy>=3.0
-      - pydantic==1.10
+      - pydantic<2
       - typing-extensions>=3.7
       - flake8
       - lmfit>=1.0.2

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -16,7 +16,7 @@ dependencies:
       - monty>=2.0.4
       - csdmpy>=0.6.dev2
       - astropy>=3.0
-      - pydantic==1.10
+      - pydantic<2
       - typing-extensions>=3.7
       - lmfit>=1.0.2
       - psutil>=5.4.8

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
       - monty>=2.0.4
       - csdmpy>=0.6.dev2
       - astropy<=5.1
-      - pydantic==1.10
+      - pydantic<2
       - typing-extensions>=3.7
       - lmfit>=1.0.2
       - psutil>=5.4.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,12 +3,12 @@ numpy>=1.20
 matplotlib>=3.3.4
 csdmpy>=0.6.dev2
 astropy>=3.0
-pydantic==1.10
+pydantic<2
 monty>=2.0.4
 typing-extensions>=3.7
 lmfit>=1.0.3
 pandas>=1.1.3
-numexpr>=2.7.1
+numexpr==2.8.4
 psutil>=5.4.8
 joblib>=1.0.0
 nmrglue>=0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ numpy>=1.20
 matplotlib>=3.3.4
 csdmpy>=0.6.dev2
 astropy>=3.0
-pydantic==1.10
+pydantic<2
 monty>=2.0.4
 typing-extensions>=3.7
 lmfit>=1.0.3
 pandas>=1.1.3
-numexpr>=2.7.1
+numexpr==2.8.4
 psutil>=5.4.8
 joblib>=1.0.0
 nmrglue>=0.9

--- a/setup.py
+++ b/setup.py
@@ -423,7 +423,7 @@ setup(
     install_requires=[
         "numpy>=1.20",
         "csdmpy>=0.4.1",
-        "pydantic==1.10",
+        "pydantic<2",
         "monty>=2.0.4",
         "typing-extensions>=3.7",
         "psutil>=5.4.8",


### PR DESCRIPTION
Update version requirements
- `pydantic<2`
- `numexpr==2.8.4`

Temporarily set the `numexpr` version until the fix for scientific notation is released.