### PR TITLE
djs/Include sphere option for volume integration

### DIFF
--- a/docs/user_guide/simulator/simulator.rst
+++ b/docs/user_guide/simulator/simulator.rst
@@ -73,7 +73,7 @@ some of these issues.
     # Create the Simulator object
     sim = Simulator(spin_systems=[system], methods=[method])
 
-Here, ``sim`` is a :ref:`simulator_api` object which holds one spin system and one method.
+Here, ``sim`` is a :ref:`simulator_api` object that holds one spin system and one method.
 See :ref:`spin_system_documentation` and :ref:`method_documentation` documentation for more
 information on the respective classes.
 
@@ -83,9 +83,9 @@ Integration Volume
 ''''''''''''''''''
 
 The attribute :py:attr:`~mrsimulator.simulator.ConfigSimulator.integration_volume` is an
-enumeration with two string literals, ``octant`` and ``hemisphere``. The integration volume
+enumeration of string literals, ``octant``, ``hemisphere``, and ``sphere``. The integration volume
 refers to the volume of a unit sphere over which the integrated NMR frequencies are evaluated.
-The default value is ``octant``, i.e., the spectrum comprises of integrated frequencies
+The default value is ``octant``, i.e., the spectrum comprises integrated frequencies
 from the positive octant of a unit sphere. **mrsimulator** can exploit the problem's
 orientational symmetry, thus optimizing the simulation by performing a partial integration.
 
@@ -133,7 +133,7 @@ The total number of orientations, :math:`\Theta_\text{count}`, is
 
     \Theta_\text{count} = M (n + 1)(n + 2)/2
 
-where :math:`M` is the number of octants and :math:`n` is value of this attribute. The
+where :math:`M` is the number of octants and :math:`n` is the value of this attribute. The
 number of octants is the value from the ``integration_volume`` attribute.
 The default value of this attribute, 70, produces 2556 orientations at which the NMR
 frequency contributions are evaluated.
@@ -142,7 +142,7 @@ frequency contributions are evaluated.
 
 .. plot::
     :context: close-figs
-    :caption: Low quality simulation from reduced integration density (=10).
+    :caption: Low-quality simulation from reduced integration density (=10).
 
     sim.config.integration_density = 10
     sim.run()
@@ -152,7 +152,7 @@ frequency contributions are evaluated.
 
 .. plot::
     :context: close-figs
-    :caption: High quality simulation from increased integration density (=100).
+    :caption: High-quality simulation from increased integration density (=100).
 
     sim.config.integration_density = 100
     sim.run()
@@ -167,7 +167,7 @@ Number of Sidebands
 '''''''''''''''''''
 
 The :py:attr:`~mrsimulator.simulator.ConfigSimulator.number_of_sidebands` attribute determines
-the number of sidebands evaluated in the simulation. The default value is 64 and is sufficient
+the number of sidebands evaluated in the simulation. The default value is 64 which is sufficient
 for most cases.
 
 In certain circumstances, especially when the anisotropy is large or the rotor spin frequency
@@ -177,7 +177,7 @@ is low, 64 sidebands might not be sufficient.
 
 .. plot::
     :context: close-figs
-    :caption: Inaccurate sideband simulation resulting from computing low number of sidebands.
+    :caption: Inaccurate sideband simulation resulting from computing a low number of sidebands.
 
     sim.methods[0] = BlochDecaySpectrum(
         channels=["29Si"],
@@ -221,7 +221,7 @@ use a large number of gamma angles for the simulation to converge.
 
 .. plot::
     :context: close-figs
-    :caption: Incorrect simulation from insufficient number of gamma angle averaging.
+    :caption: Incorrect simulation from an insufficient number of gamma angle averaging.
 
     from mrsimulator.method import Method
     from mrsimulator.method.event import SpectralEvent, MixingEvent
@@ -255,7 +255,7 @@ To resolve this, increase the number of gamma angles.
 
 .. plot::
     :context: close-figs
-    :caption: Accurate simulation from sufficiently large number of gamma angle averaging.
+    :caption: Accurate simulation from a sufficiently large number of gamma angle averaging.
 
     sim.config.number_of_gamma_angles=1000
     sim.run()
@@ -276,7 +276,7 @@ following example.
 
 .. plot::
     :context: close-figs
-    :caption: The frequency contributions from each individual spin systems are
+    :caption: The frequency contributions from individual spin systems are
         combined into one spectrum.
 
     # Create two distinct sites
@@ -371,8 +371,8 @@ Attribute Summaries
   * - integration_volume
     - ``str``
     - An *optional* string representing the fraction of a unit sphere used in the integrated NMR
-      frequency spectra. The allowed strings are ``octant`` and ``hemisphere``. The default
-      is ``octant``.
+      frequency spectra. The allowed strings are ``octant``, ``hemisphere``, and ``sphere``. The
+      default is ``octant``.
 
   * - integration_density
     - ``int``

--- a/src/c_lib/lib/angular_momentum/wigner_matrix.c
+++ b/src/c_lib/lib/angular_momentum/wigner_matrix.c
@@ -741,7 +741,8 @@ void __batch_wigner_rotation(const unsigned int octant_orientations,
                              const unsigned int n_octants, double *wigner_2j_matrices,
                              complex128 *R2, double *wigner_4j_matrices, complex128 *R4,
                              complex128 *exp_Im_alpha, complex128 *w2, complex128 *w4) {
-  unsigned int j, wigner_2j_inc, wigner_4j_inc = 0, w2_increment, w4_increment = 0;
+  unsigned int j, max_iter, wigner_2j_inc, wigner_4j_inc = 0, w2_increment,
+                                           w4_increment = 0;
 
   w2_increment = 3 * octant_orientations;
   wigner_2j_inc = 5 * w2_increment;  // equal to 5 x 3 x octant_orientations;
@@ -750,7 +751,8 @@ void __batch_wigner_rotation(const unsigned int octant_orientations,
     wigner_4j_inc = 9 * w4_increment;  // equal to 9 x 5 x octant_orientations;
   }
 
-  for (j = 0; j < n_octants; j++) {
+  max_iter = (n_octants <= 4) ? n_octants : 4;
+  for (j = 0; j < max_iter; j++) {
     /* Second-rank Wigner rotation from crystal/common frame to rotor frame. */
     __wigner_rotation_2(2, octant_orientations, wigner_2j_matrices, exp_Im_alpha, R2,
                         w2);

--- a/src/mrsimulator/simulator/config.py
+++ b/src/mrsimulator/simulator/config.py
@@ -12,8 +12,8 @@ __decompose_spectrum_enum__ = {"none": 0, "spin_system": 1}
 __isotropic_interpolation_enum__ = {"linear": 0, "gaussian": 1}
 
 # integration volume
-__integration_volume_enum__ = {"octant": 0, "hemisphere": 1}
-__integration_volume_octants__ = [1, 4]
+__integration_volume_enum__ = {"octant": 0, "hemisphere": 1, "sphere": 2}
+__integration_volume_octants__ = [1, 4, 8]
 
 
 class ConfigSimulator(Parseable):
@@ -34,8 +34,9 @@ class ConfigSimulator(Parseable):
         The spatial volume over which the spectral frequency integration/averaging
         is performed. The valid literals of this enumeration are
 
-        - ``octant`` (default), and
-        - ``hemisphere``
+        - ``octant`` (default),
+        - ``hemisphere``, and
+        - ``sphere``
 
     integration_density: int (optional).
         The integration/sampling density or equivalently the number of (alpha, beta)
@@ -78,7 +79,7 @@ class ConfigSimulator(Parseable):
 
     number_of_sidebands: int = Field(default=64, gt=0)
     number_of_gamma_angles: int = Field(default=1, gt=0)
-    integration_volume: Literal["octant", "hemisphere"] = "octant"
+    integration_volume: Literal["octant", "hemisphere", "sphere"] = "octant"
     integration_density: int = Field(default=70, gt=0)
     decompose_spectrum: Literal["none", "spin_system"] = "none"
     isotropic_interpolation: Literal["linear", "gaussian"] = "linear"

--- a/src/mrsimulator/simulator/tests/test_config.py
+++ b/src/mrsimulator/simulator/tests/test_config.py
@@ -52,7 +52,7 @@ def test_config():
 
     error = "unexpected value; permitted: 'octant', 'hemisphere'"
     with pytest.raises(ValueError, match=f".*{error}.*"):
-        a.config.integration_volume = "sphere"
+        a.config.integration_volume = "pentagon"
 
     # decompose spectrum
     assert a.config.decompose_spectrum == "none"
@@ -81,7 +81,7 @@ def test_config():
     with pytest.raises(ValueError, match=f".*{error}.*"):
         a.config.integration_density = -1
 
-    # overall
+    # overall hemisphere
     assert a.config.dict(exclude={"property_units"}) == {
         "decompose_spectrum": "spin_system",
         "number_of_sidebands": 10,
@@ -107,3 +107,32 @@ def test_config():
 
     # get orientation count
     assert a.config.get_orientations_count() == 4 * 21 * 22 * 14 / 2
+
+    # overall sphere
+    a.config.integration_volume = "sphere"
+    assert a.config.integration_volume == "sphere"
+    assert a.config.dict(exclude={"property_units"}) == {
+        "decompose_spectrum": "spin_system",
+        "number_of_sidebands": 10,
+        "number_of_gamma_angles": 14,
+        "integration_volume": "sphere",
+        "integration_density": 20,
+        "isotropic_interpolation": "gaussian",
+        "name": None,
+        "description": None,
+        "label": None,
+    }
+
+    assert a.config.get_int_dict() == {
+        "decompose_spectrum": 1,
+        "number_of_sidebands": 10,
+        "number_of_gamma_angles": 14,
+        "integration_volume": 2,
+        "integration_density": 20,
+        "isotropic_interpolation": 1,
+    }
+
+    assert b != a
+
+    # get orientation count
+    assert a.config.get_orientations_count() == 4 * 21 * 22 * 14

--- a/tests/spectral_integration_tests/test_lineshapes.py
+++ b/tests/spectral_integration_tests/test_lineshapes.py
@@ -153,21 +153,22 @@ def test_pure_quadrupolar_sidebands_simpson():
     for i in range(2):
         message = f"{error_message} test0{i:02d}.json"
         filename = path.join(path_, f"test{i:02d}", f"test{i:02d}.json")
-        data_mrsimulator, data_source = c_setup(
-            filename=filename, integration_volume="hemisphere"
-        )
+        for volume in ["hemisphere", "sphere"]:
+            data_mrsimulator, data_source = c_setup(
+                filename=filename, integration_volume=volume
+            )
 
-        # if SHOW_PLOTS:
-        #     plt.plot(data_mrsimulator, "k", label="mrsims")
-        #     plt.plot(data_source, "--r", label="simpson")
-        #     plt.title("Quad Sidebands")
-        #     plt.legend()
-        #     plt.show()
+            # if SHOW_PLOTS:
+            #     plt.plot(data_mrsimulator, "k", label="mrsims")
+            #     plt.plot(data_source, "--r", label="simpson")
+            #     plt.title("Quad Sidebands")
+            #     plt.legend()
+            #     plt.show()
 
-        limit = -np.log10(data_source.max()) + 1.5
-        np.testing.assert_almost_equal(
-            data_mrsimulator, data_source, decimal=limit, err_msg=message
-        )
+            limit = -np.log10(data_source.max()) + 1.5
+            np.testing.assert_almost_equal(
+                data_mrsimulator, data_source, decimal=limit, err_msg=message
+            )
 
         # random euler angle all zero. Euler angles should not affect the spectrum.
         data_mrsimulator, data_source = c_setup_random_euler_angles(
@@ -194,21 +195,22 @@ def test_csa_plus_quadrupolar_lineshape_simpson():
     for i in range(6):
         message = f"{error_message} test0{i:02d}.json"
         filename = path.join(path_, f"test{i:02d}", f"test{i:02d}.json")
-        data_mrsimulator, data_source = c_setup(
-            filename=filename, integration_volume="hemisphere"
-        )
+        for volume in ["hemisphere", "sphere"]:
+            data_mrsimulator, data_source = c_setup(
+                filename=filename, integration_volume=volume
+            )
 
-        # if SHOW_PLOTS:
-        #     plt.plot(data_mrsimulator, "k", label="mrsims")
-        #     plt.plot(data_source, "--r", label="simpson")
-        #     plt.title("Quad + Shielding Sidebands")
-        #     plt.legend()
-        #     plt.show()
+            # if SHOW_PLOTS:
+            #     plt.plot(data_mrsimulator, "k", label="mrsims")
+            #     plt.plot(data_source, "--r", label="simpson")
+            #     plt.title("Quad + Shielding Sidebands")
+            #     plt.legend()
+            #     plt.show()
 
-        limit = -np.log10(data_source.max()) + 1
-        np.testing.assert_almost_equal(
-            data_mrsimulator, data_source, decimal=limit, err_msg=message
-        )
+            limit = -np.log10(data_source.max()) + 1
+            np.testing.assert_almost_equal(
+                data_mrsimulator, data_source, decimal=limit, err_msg=message
+            )
 
 
 def test_1st_order_quadrupolar_lineshape_simpson():
@@ -219,21 +221,22 @@ def test_1st_order_quadrupolar_lineshape_simpson():
     for i in range(2):
         message = f"{error_message} test0{i:02d}.json"
         filename = path.join(path_, f"test{i:02d}", f"test{i:02d}.json")
-        data_mrsimulator, data_source = c_setup(
-            filename=filename, integration_volume="hemisphere"
-        )
+        for volume in ["hemisphere", "sphere"]:
+            data_mrsimulator, data_source = c_setup(
+                filename=filename, integration_volume=volume
+            )
 
-        # if SHOW_PLOTS:
-        #     plt.plot(data_mrsimulator, "k", label="mrsims")
-        #     plt.plot(data_source, "--r", label="simpson")
-        #     plt.title("Quad + Shielding Sidebands")
-        #     plt.legend()
-        #     plt.show()
+            # if SHOW_PLOTS:
+            #     plt.plot(data_mrsimulator, "k", label="mrsims")
+            #     plt.plot(data_source, "--r", label="simpson")
+            #     plt.title("Quad + Shielding Sidebands")
+            #     plt.legend()
+            #     plt.show()
 
-        limit = -np.log10(data_source.max()) + 1
-        np.testing.assert_almost_equal(
-            data_mrsimulator, data_source, decimal=limit, err_msg=message
-        )
+            limit = -np.log10(data_source.max()) + 1
+            np.testing.assert_almost_equal(
+                data_mrsimulator, data_source, decimal=limit, err_msg=message
+            )
 
 
 def test_j_coupling_lineshape_simpson():
@@ -242,22 +245,22 @@ def test_j_coupling_lineshape_simpson():
     for i in range(20):
         message = f"{error_message} test0{i:02d}.json"
         filename = path.join(path_, f"test{i:02d}", f"test{i:02d}.json")
-        data_mrsimulator, data_source = c_setup(
-            filename=filename,
-            integration_volume="hemisphere",
-        )
+        for volume in ["hemisphere", "sphere"]:
+            data_mrsimulator, data_source = c_setup(
+                filename=filename, integration_volume=volume
+            )
 
-        # if SHOW_PLOTS:
-        #     plt.plot(data_mrsimulator, "k", label="mrsims")
-        #     plt.plot(data_source, "--r", label="simpson")
-        #     plt.title("J-coupling Spectra")
-        #     plt.legend()
-        #     plt.show()
+            # if SHOW_PLOTS:
+            #     plt.plot(data_mrsimulator, "k", label="mrsims")
+            #     plt.plot(data_source, "--r", label="simpson")
+            #     plt.title("J-coupling Spectra")
+            #     plt.legend()
+            #     plt.show()
 
-        limit = -np.log10(data_source.max()) + 1.1
-        np.testing.assert_almost_equal(
-            data_mrsimulator, data_source, decimal=limit, err_msg=message
-        )
+            limit = -np.log10(data_source.max()) + 1.1
+            np.testing.assert_almost_equal(
+                data_mrsimulator, data_source, decimal=limit, err_msg=message
+            )
 
 
 def test_dipolar_coupling_lineshape_simpson():
@@ -268,18 +271,19 @@ def test_dipolar_coupling_lineshape_simpson():
     for i in range(7):
         message = f"{error_message} test0{i:02d}.json"
         filename = path.join(path_, f"test{i:02d}", f"test{i:02d}.json")
-        data_mrsimulator, data_source = c_setup(
-            filename=filename, integration_volume="hemisphere"
-        )
+        for volume in ["hemisphere", "sphere"]:
+            data_mrsimulator, data_source = c_setup(
+                filename=filename, integration_volume=volume
+            )
 
-        # if SHOW_PLOTS:
-        #     plt.plot(data_mrsimulator, "k", label="mrsims")
-        #     plt.plot(data_source, "--r", label="simpson")
-        #     plt.title("Dipolar-coupling Spectra")
-        #     plt.legend()
-        #     plt.show()
+            # if SHOW_PLOTS:
+            #     plt.plot(data_mrsimulator, "k", label="mrsims")
+            #     plt.plot(data_source, "--r", label="simpson")
+            #     plt.title("Dipolar-coupling Spectra")
+            #     plt.legend()
+            #     plt.show()
 
-        limit = -np.log10(data_source.max()) + 1.5
-        np.testing.assert_almost_equal(
-            data_mrsimulator, data_source, decimal=limit, err_msg=message
-        )
+            limit = -np.log10(data_source.max()) + 1.5
+            np.testing.assert_almost_equal(
+                data_mrsimulator, data_source, decimal=limit, err_msg=message
+            )

--- a/tests/test_amplitude.py
+++ b/tests/test_amplitude.py
@@ -49,6 +49,10 @@ def test_with_configuration_setting():
     sim.run()
     y_static_1 = sim.methods[0].simulation.y[0].components[0].sum()
 
+    sim.config.integration_volume = "sphere"
+    sim.run()
+    y_static_3 = sim.methods[0].simulation.y[0].components[0].sum()
+
     sim.config.integration_volume = "hemisphere"
     sim.run()
     y_static_2 = sim.methods[0].simulation.y[0].components[0].sum()
@@ -64,8 +68,11 @@ def test_with_configuration_setting():
     e = "Integral error from changing integration density."
     np.testing.assert_almost_equal(y_static, y_static_1, decimal=1, err_msg=e)
 
-    e = "Integral error from changing integration volume."
+    e = "Integral error from changing integration volume octant to hemisphere."
     np.testing.assert_almost_equal(y_static, y_static_2, decimal=1, err_msg=e)
+
+    e = "Integral error from changing integration volume from octant to sphere."
+    np.testing.assert_almost_equal(y_static, y_static_3, decimal=1, err_msg=e)
 
     e = "Integral error from νr, integration density, integration volume."
     np.testing.assert_almost_equal(y_static, y_MAS, decimal=1, err_msg=e)


### PR DESCRIPTION
### Test code
```py
import numpy as np
import matplotlib.pyplot as plt

from mrsimulator import Simulator, SpinSystem, Site
from mrsimulator.method.lib import BlochDecayCTSpectrum
from mrsimulator.spin_system.tensors import SymmetricTensor
from mrsimulator.method import SpectralDimension


# Create the spin system.
site = Site(
    isotope="17O",
    isotropic_chemical_shift=320,  # in ppm
    shielding_symmetric=SymmetricTensor(zeta=376.667, eta=0.345),
    quadrupolar=SymmetricTensor(
        Cq=8.97e6,  eta=0.15, alpha=5 * np.pi / 180, beta=np.pi / 2, gamma=70 * np.pi / 180
    ),
)
spin_system = SpinSystem(sites=[site])


# Create a central transition selective Bloch decay spectrum method.
method = BlochDecayCTSpectrum(
    channels=["17O"],
    magnetic_flux_density=11.74,  # in T
    rotor_frequency=0,  # in Hz
    rotor_angle=0,  # in rads
    spectral_dimensions=[
        SpectralDimension(
            count=1024, spectral_width=1e5, reference_offset=22500, label=r"$^{17}$O resonances"
        )
    ],
)

# Create the Simulator object and add method and spin system objects.
sim = Simulator(spin_systems=[spin_system], methods=[method])

# Since the spin system have non-zero Euler angles, set the integration_volume to
# hemisphere.
sim.config.integration_volume = "hemisphere"
sim.run()
hemisphere_sim = sim.methods[0].simulation.real

sim.config.integration_volume = "sphere"
sim.run()
sphere_sim = sim.methods[0].simulation.real

# The plot of the simulation before signal processing.
plt.figure(figsize=(4.25, 3.0))
ax = plt.subplot(projection="csdm")
ax.plot(hemisphere_sim, color="black", linewidth=1, label='hemisphere')
ax.plot(sphere_sim, color="red", linewidth=1, linestyle='--', label='sphere')
ax.invert_xaxis()
plt.legend()
plt.tight_layout()
plt.show()
```


![test_hemisphere_sphere](https://github.com/deepanshs/mrsimulator/assets/21365911/01120027-0b2a-46f6-8c5c-82d5bf43245c)