### PR TITLE
Add support for analytical czjzek distribution

### DIFF
--- a/src/mrsimulator/models/analytical_distributions.py
+++ b/src/mrsimulator/models/analytical_distributions.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+
+__author__ = "Deepansh J. Srivastava"
+__email__ = "dsrivastava@hyperfine.io"
+
+
+def czjzek(sigma, zeta, eta):
+    """Analytical czjzek distribution
+
+    Args:
+        sigma: czjzek standard distribution
+        zeta: zeta array
+        eta: eta array
+    """
+    sigma_ = 2 * sigma
+    denom = np.sqrt(2 * np.pi) * sigma_**5
+    res = (zeta**4 * eta) * (1 - eta**2 / 9) / denom
+    res *= np.exp(-(zeta**2 * (1 + (eta**2 / 3))) / (2 * sigma_**2))
+    res /= res.sum()
+    return res

--- a/src/mrsimulator/models/czjzek.py
+++ b/src/mrsimulator/models/czjzek.py
@@ -1,3 +1,9 @@
+"""
+Analytical czjzek ditribution on polar and non-polar grid
+
+__author__ = "Deepansh J. Srivastava"
+__email__ = "dsrivastava@hyperfine.io"
+"""
 import mrsimulator.models.analytical_distributions as analytical_dist
 import numpy as np
 from mrsimulator.spin_system.tensors import SymmetricTensor
@@ -91,54 +97,8 @@ class AbstractDistribution:
             >>> Cq_dist, eta_dist, amp = cz_model.pdf(pos=[cq, eta])
         """
         if analytical and self.model_name in ANALYTICAL_AVAILABLE:
-            polar = self.polar
             analytical_model = ANALYTICAL_AVAILABLE[self.model_name]
-            if polar:
-                # x, y = np.meshgrid(pos[0], pos[1])
-
-                bins = [pos[0].size, pos[1].size]
-
-                max_val = np.sqrt(pos[0][-1] ** 2 + pos[1][-1] ** 2)
-                max_size = int(np.max(bins) * np.sqrt(2)) * 10
-                zeta_1d = 2 * max_val * (np.arange(max_size) / max_size)
-                eta_1d = np.arange(max_size) / (max_size - 1)
-                zeta, eta = np.meshgrid(zeta_1d, eta_1d)
-
-                pdf_model = analytical_model(self.sigma, zeta, eta)
-                x, y = x_y_from_zeta_eta(zeta.ravel(), eta.ravel())
-
-                delta_z = (pos[0][1] - pos[0][0]) / 2
-                delta_e = (pos[1][1] - pos[1][0]) / 2
-                range_x = [pos[0][0] - delta_z, pos[0][-1] + delta_z]
-                range_y = [pos[1][0] - delta_e, pos[1][-1] + delta_e]
-
-                hist_x_y, _, _ = np.histogram2d(
-                    x, y, weights=pdf_model.ravel(), bins=bins, range=[range_x, range_y]
-                )
-
-                hist_x_y += hist_x_y.T
-                # for i in range(np.min(bins)):
-                #     hist_x_y[i, i] /= 2.0
-                hist_x_y /= hist_x_y.sum()
-
-                # avg_row_model = 0.0
-                # for i in range(avg_step):
-                #     avg_row_model += pdf_model[i::avg_step]
-
-                # avg_model = 0.0
-                # for i in range(avg_step):
-                #     avg_model += avg_row_model[:, i::avg_step]
-                return x, y, hist_x_y
-            else:
-                sub_zero = np.where(pos[1] < 0)[0]
-                super_one = np.where(pos[1] > 1)[0]
-                zeta, eta = np.meshgrid(pos[0], pos[1])
-                pdf_model = analytical_model(self.sigma, zeta, eta)
-                pdf_model[sub_zero] = 0
-                pdf_model[super_one] = 0
-                if eta.max() == 1:
-                    pdf_model[-1] /= 2
-            return zeta, eta, pdf_model
+            return analytical_model(self.sigma, pos, self.polar)
         else:
             return self.pdf_numerical(pos, size)
 

--- a/src/mrsimulator/models/tests/test_czjzek_and_extended_czjzek.py
+++ b/src/mrsimulator/models/tests/test_czjzek_and_extended_czjzek.py
@@ -78,12 +78,7 @@ def test_czjzek_distribution():
     z_range = (ran_z[1:] + ran_z[:-1]) / 2
 
     # czjzek distribution from analytical formula
-    sigma_ = 2 * sigma
-    V, e = np.meshgrid(z_range, e_range)
-    denom = (2 * np.pi) ** 0.5 * sigma_**5
-    res = (V**4 * e) * (1 - e**2 / 9) / denom
-    res *= np.exp(-(V**2 * (1 + (e**2 / 3))) / (2 * sigma_**2))
-    res /= res.sum()
+    _, _, res = CzjzekDistribution(sigma).pdf(pos=[z_range, e_range])
 
     eta_pro = res.sum(axis=1)
     zeta_pro = res.sum(axis=0)
@@ -97,20 +92,44 @@ def test_czjzek_distribution():
     np.testing.assert_almost_equal(z_vector, zeta_pro, decimal=2, err_msg=message)
 
 
-def test_czjzek_pdf():
+def test_czjzek_pdf_full_eta():
     sigma = 0.5
     z_range = np.arange(100) * 30 / 100 - 15
     e_range = np.arange(21) / 20
 
     # czjzek distribution from analytical formula
-    sigma_ = 2 * sigma
-    V, e = np.meshgrid(z_range, e_range)
-    denom = (2 * np.pi) ** 0.5 * sigma_**5
-    res = (V**4 * e) * (1 - e**2 / 9) / denom
-    res *= np.exp(-(V**2 * (1 + (e**2 / 3))) / (2 * sigma_**2))
-    res /= res.sum()
+    _, _, res = CzjzekDistribution(sigma).pdf(pos=[z_range, e_range], analytical=True)
 
-    _, _, amp = CzjzekDistribution(sigma).pdf([z_range, e_range])
+    _, _, amp = CzjzekDistribution(sigma).pdf([z_range, e_range], analytical=False)
+
+    error = "Czjzek analytical is not equal to numerical"
+    np.testing.assert_almost_equal(res, amp, decimal=2, err_msg=error)
+
+
+def test_czjzek_polar_analytical_vs_numerical():
+    x_range = np.linspace(0, 12, 100)
+    y_range = np.linspace(0, 12, 100)
+
+    czjzek_dist = CzjzekDistribution(sigma=1.25, polar=True)
+    # The 2D amplitude grid of Cq and eta is sampled from the Czjzek distribution model.
+    _, _, amp_ana = czjzek_dist.pdf(pos=[x_range, y_range], analytical=True)
+    _, _, amp_num = czjzek_dist.pdf(
+        pos=[x_range, y_range], analytical=False, size=1_000_000
+    )
+
+    error = "Czjzek analytical is not equal to numerical"
+    np.testing.assert_almost_equal(amp_ana, amp_num, decimal=2, err_msg=error)
+
+
+def test_czjzek_pdf_sub_eta():
+    sigma = 0.5
+    z_range = np.arange(100) * 30 / 100 - 15
+    e_range = np.arange(21) / 21
+
+    # czjzek distribution from analytical formula
+    _, _, res = CzjzekDistribution(sigma).pdf(pos=[z_range, e_range], analytical=True)
+
+    _, _, amp = CzjzekDistribution(sigma).pdf([z_range, e_range], analytical=False)
 
     error = "Czjzek analytical is not equal to numerical"
     np.testing.assert_almost_equal(res, amp, decimal=2, err_msg=error)

--- a/src/mrsimulator/models/utils.py
+++ b/src/mrsimulator/models/utils.py
@@ -70,10 +70,10 @@ def x_y_to_zeta_eta(x, y):
     zeta = np.sqrt(x**2 + y**2)  # + offset
     eta = np.ones(zeta.shape)
     index = np.where(x > y)
-    zeta[index] = -zeta[index]
+    zeta[index] *= -1
     eta[index] = (4.0 / np.pi) * np.arctan(y[index] / x[index])
 
     index = np.where(x < y)
     eta[index] = (4.0 / np.pi) * np.arctan(x[index] / y[index])
 
-    return zeta.ravel(), eta.ravel()
+    return zeta, eta


### PR DESCRIPTION
### Analytical expression for computing czjzek distribution

The syntax remains the same, but analytical model is preferred for distributions when available

```py
czjzek = CzjzekDistribution(sigma=1.25,polar=True)

# default is analytics (~0.2 s)
x_dist1, y_dist1, amp1 = czjzek.pdf(pos=[x_range, y_range])

# to force numerical computation (~15.5 s)
x_dist0, y_dist0, amp0 = czjzek.pdf(pos=[x_range, y_range], analytical=False, size=10_000_000)
```

### Comparison test
![test_compare](https://github.com/deepanshs/mrsimulator/assets/21365911/a6dea4be-ed52-4101-9daa-62d3f6dd1c0a)
