### PR TITLE
DJS/remove period from csdm dimension for simulations

### DIFF
--- a/src/mrsimulator/method/spectral_dimension.py
+++ b/src/mrsimulator/method/spectral_dimension.py
@@ -186,7 +186,7 @@ class SpectralDimension(Parseable):
 
         default_reciprocal = {
             "coordinates_offset": f"{-1/(2*increment)} s",
-            "period": f"{1/increment} s",
+            # "period": f"{1/increment} s",
         }
         reciprocal = (
             default_reciprocal if self.reciprocal is None else self.reciprocal.json()
@@ -200,7 +200,7 @@ class SpectralDimension(Parseable):
             label=label,
             description=description,
             complex_fft=True,
-            period=f"{self.spectral_width} Hz",
+            # period=f"{self.spectral_width} Hz",
             reciprocal=reciprocal,
         )
         if self.origin_offset is not None:


### PR DESCRIPTION
Bug fix where dimensions were returned as periodic dimensions.

```py
from mrsimulator import Simulator, SpinSystem, Site
from mrsimulator.method.lib import BlochDecaySpectrum
import matplotlib.pyplot as plt

H_site = Site(isotope="1H", shielding_symmetric={"zeta": 13.89, "eta": 0.25})
spin_system = SpinSystem(sites=[H_site])

static = BlochDecaySpectrum(channels=["1H"])
mas = BlochDecaySpectrum(channels=["1H"], rotor_frequency=1000)  # in Hz

sim = Simulator(spin_systems=[spin_system], methods=[static, mas])
sim.run()

print(sim.methods[0].simulation.x[0].period)
```
return period as `np.inf Hz`