### PR TITLE
Support for mac arm arc builds on GitHub runner

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -120,10 +120,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - os: macos-12
-          #   name: mac 64-bit x86_64
-          #   cibw:
-          #     build: "cp3*"
+          - os: macos-12
+            name: mac 64-bit x86_64
+            cibw:
+              build: "cp3*"
 
           - os: macos-14
             name: mac 64-bit arm64
@@ -131,11 +131,11 @@ jobs:
               arch: arm64
               build: "cp3*"
 
-          # - os: ubuntu-latest
-          #   name: linux 64-bit x86_64
-          #   cibw:
-          #     build: "cp3*manylinux_x86_64"
-          #     manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            name: linux 64-bit x86_64
+            cibw:
+              build: "cp3*manylinux_x86_64"
+              manylinux_image: manylinux2014
 
           # - os: ubuntu-latest
           #   name: linux 32-bit i686
@@ -162,10 +162,10 @@ jobs:
           #   cibw:
           #     build: "pp*win32"
 
-          # - os: windows-latest
-          #   name: windows 64-bit AMD64
-          #   cibw:
-          #     build: "cp3*win_amd64"
+          - os: windows-latest
+            name: windows 64-bit AMD64
+            cibw:
+              build: "cp3*win_amd64"
 
     steps:
       - name: Checkout

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -120,22 +120,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-12
-            name: mac 64-bit x86_64
-            cibw:
-              build: "cp3*"
+          # - os: macos-12
+          #   name: mac 64-bit x86_64
+          #   cibw:
+          #     build: "cp3*"
 
-          - os: macos-13
+          - os: macos-14
             name: mac 64-bit arm64
             cibw:
               arch: arm64
               build: "cp3*"
 
-          - os: ubuntu-latest
-            name: linux 64-bit x86_64
-            cibw:
-              build: "cp3*manylinux_x86_64"
-              manylinux_image: manylinux2014
+          # - os: ubuntu-latest
+          #   name: linux 64-bit x86_64
+          #   cibw:
+          #     build: "cp3*manylinux_x86_64"
+          #     manylinux_image: manylinux2014
 
           # - os: ubuntu-latest
           #   name: linux 32-bit i686
@@ -162,10 +162,10 @@ jobs:
           #   cibw:
           #     build: "pp*win32"
 
-          - os: windows-latest
-            name: windows 64-bit AMD64
-            cibw:
-              build: "cp3*win_amd64"
+          # - os: windows-latest
+          #   name: windows 64-bit AMD64
+          #   cibw:
+          #     build: "cp3*win_amd64"
 
     steps:
       - name: Checkout
@@ -177,9 +177,10 @@ jobs:
           python-version: "3.10"
           architecture: ${{ matrix.architecture }}
 
-      # - name: customize mac-arm-64
-      #   if: contains(matrix.os, 'macos') && matrix.cibw.arch
-      #   run: |
+      - name: customize mac-arm-64
+        if: contains(matrix.os, 'macos') && matrix.cibw.arch
+        run: |
+          echo 'MACOSX_DEPLOYMENT_TARGET=14' >> "$GITHUB_ENV"
       #     sudo xcode-select -switch /Applications/Xcode_13.1.app
       #     echo 'SDKROOT=/Applications/Xcode_13.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk' >> "$GITHUB_ENV"
       #     echo 'MACOSX_DEPLOYMENT_TARGET=11.1' >> "$GITHUB_ENV"


### PR DESCRIPTION
Add build for Mac arm arch on GitHub runner. GitHub runner support m1 Mac starting macosx 14.