### PR TITLE
fix windows access violation error

### DIFF
--- a/src/c_lib/lib/mrsimulator.c
+++ b/src/c_lib/lib/mrsimulator.c
@@ -416,7 +416,7 @@ void MRS_get_normalized_frequencies_from_plan(MRS_averaging_scheme *scheme,
     fraction_duration = dim->inverse_increment * fraction;
   } else {
     local_frequency = dim->local_phase;
-    cblas_dscal(freq_size, 0.0, local_frequency, 1);
+    vm_double_zeros(freq_size, local_frequency);
     fraction_duration = CONST_2PI * duration;
   }
 


### PR DESCRIPTION
The source of the Window access violation issue is the same as Mac NaN issues:
The issue was related to the recent update in openblas lib.

For release note:

Fixed corner cases involving the handling of NAN and INFINITY arguments in ?SCAL on all architectures

https://github.com/OpenMathLib/OpenBLAS/pull/4829/files
