### PR TITLE
Point DMFIT example datasets at ssnmr.org

### DIFF
--- a/fitting_source/1D_fitting/plot_1_31P_Na2PO4_MAS.py
+++ b/fitting_source/1D_fitting/plot_1_31P_Na2PO4_MAS.py
@@ -38,7 +38,7 @@ from mrsimulator.spin_system.tensors import SymmetricTensor
 # Import the experimental data. We use dataset file serialized with the CSDM
 # file-format, using the
 # `csdmpy <https://csdmpy.readthedocs.io/en/stable/index.html>`_ module.
-host = "https://nmr.cemhti.cnrs-orleans.fr/Dmfit/Help/csdm/"
+host = "https://ssnmr.org/sites/default/files/mrsimulator/"
 filename = "31P Phosphate 6kHz.csdf"
 experiment = cp.load(host + filename)
 

--- a/fitting_source/1D_fitting/plot_1_31p_Na2PO4_static.py
+++ b/fitting_source/1D_fitting/plot_1_31p_Na2PO4_static.py
@@ -25,7 +25,7 @@ from mrsimulator.spin_system.tensors import SymmetricTensor
 # %%
 # Import the dataset
 # ------------------
-host = "https://nmr.cemhti.cnrs-orleans.fr/Dmfit/Help/csdm/"
+host = "https://ssnmr.org/sites/default/files/mrsimulator/"
 filename = "31P Phophonate Static.csdf"
 experiment = cp.load(host + filename)
 

--- a/fitting_source/1D_fitting/plot_2_13C_glycine_960Hz.py
+++ b/fitting_source/1D_fitting/plot_2_13C_glycine_960Hz.py
@@ -24,7 +24,7 @@ from mrsimulator.utils import get_spectral_dimensions
 # %%
 # Import the dataset
 # ------------------
-host = "https://nmr.cemhti.cnrs-orleans.fr/Dmfit/Help/csdm/"
+host = "https://ssnmr.org/sites/default/files/mrsimulator/"
 filename = "13C MAS 960Hz - Glycine.csdf"
 experiment = cp.load(host + filename)
 

--- a/fitting_source/1D_fitting/plot_2_13C_glycine_multi_spectra_fit.py
+++ b/fitting_source/1D_fitting/plot_2_13C_glycine_multi_spectra_fit.py
@@ -28,7 +28,7 @@ from mrsimulator.spin_system.tensors import SymmetricTensor
 # Import the datasets and assign the standard deviation of noise for each dataset. Here,
 # ``sigma1``, ``sigma2``, and ``sigma3`` are the noise standard deviation for the
 # dataset acquired at  5 kHz, 1.94 kHz, and 960 Hz spinning speeds, respectively.
-host = "https://nmr.cemhti.cnrs-orleans.fr/Dmfit/Help/csdm/"
+host = "https://ssnmr.org/sites/default/files/mrsimulator/"
 filename1 = "13C MAS 5000Hz - Glycine.csdf"
 filename2 = "13C MAS 1940Hz - Glycine.csdf"
 filename3 = "13C MAS 960Hz - Glycine.csdf"

--- a/fitting_source/1D_fitting/plot_4_27Al_YAG.py
+++ b/fitting_source/1D_fitting/plot_4_27Al_YAG.py
@@ -25,7 +25,7 @@ from mrsimulator.spin_system.tensors import SymmetricTensor
 # %%
 # Import the dataset
 # ------------------
-host = "https://nmr.cemhti.cnrs-orleans.fr/Dmfit/Help/csdm/"
+host = "https://ssnmr.org/sites/default/files/mrsimulator/"
 filename = "27Al Quad MAS YAG 400MHz.csdf"
 experiment = cp.load(host + filename)
 

--- a/fitting_source/1D_fitting/plot_4_2H_quad.py
+++ b/fitting_source/1D_fitting/plot_4_2H_quad.py
@@ -24,7 +24,7 @@ from mrsimulator.spin_system.tensors import SymmetricTensor
 # %%
 # Import the dataset
 # ------------------
-host = "https://nmr.cemhti.cnrs-orleans.fr/Dmfit/Help/csdm/"
+host = "https://ssnmr.org/sites/default/files/mrsimulator/"
 filename = "2H methiodine MAS.csdf"
 experiment = cp.load(host + filename)
 

--- a/fitting_source/1D_fitting/plot_6_139La_Ext_Czjzek.py
+++ b/fitting_source/1D_fitting/plot_6_139La_Ext_Czjzek.py
@@ -27,7 +27,7 @@ import matplotlib.pyplot as plt
 # %%
 # Import the dataset
 # ------------------
-host = "http://ssnmr.org/sites/default/files/"
+host = "https://ssnmr.org/sites/default/files/"
 filename = "mrsimulator/La bc - LaY90 cpmg.csdf"
 experiment = cp.load(host + filename).real
 experiment.x[0].to("ppm", "nmr_frequency_ratio")

--- a/fitting_source/1D_fitting/plot_7_27Al_Extended_Czjzek.py
+++ b/fitting_source/1D_fitting/plot_7_27Al_Extended_Czjzek.py
@@ -37,7 +37,7 @@ from mrsimulator.models.utils import LineShapeKernel
 # -------------------------------
 #
 # Below we import and visualize the experimental dataset.
-host = "http://ssnmr.org/sites/default/files/mrsimulator/"
+host = "https://ssnmr.org/sites/default/files/mrsimulator/"
 filename = "20K_20Al_10P_50Si_HahnEcho_27Al.csdf"
 exp_data = cp.load(host + filename).real
 


### PR DESCRIPTION
The CEMHTI server hosting the DMFIT example datasets fails TLS verification with a certificate hostname mismatch, which breaks six fitting examples in the docs build. The same datasets are already mirrored on ssnmr.org, so only the host URL changes and the filenames are unchanged. This also normalizes two remaining http:// dataset URLs to https://.

All eight modified examples were run locally against the new URLs and completed successfully, including the download, the simulation, and the least-squares fit.